### PR TITLE
Automatic repositioning of the tray context menu

### DIFF
--- a/KeeTrayTOTP.Tests/TrayContextMenuPositionTests.cs
+++ b/KeeTrayTOTP.Tests/TrayContextMenuPositionTests.cs
@@ -1,0 +1,119 @@
+using System.Collections.Generic;
+using System.Drawing;
+using KeeTrayTOTP.Libraries;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace KeeTrayTOTP.Tests
+{
+    [TestClass]
+    public class TrayContextMenuPositionTests
+    {
+        [DataTestMethod]
+        [DynamicData(nameof(DropDownLocationTestData))]
+        public void CalculatedLocationForDropDown_Should_ReturnTheCorrectLocation(Size controlSize, Point mousePosition,
+            Rectangle screenRect, Point expectedPoint)
+        {
+            var dropDownLocationCalculator = new DropDownLocationCalculator(controlSize);
+            var sut = dropDownLocationCalculator.CalculateLocationForDropDown(mousePosition, screenRect);
+
+            Assert.AreEqual(expectedPoint, sut);
+        }
+
+        private static IEnumerable<object[]> DropDownLocationTestData
+        {
+            get
+            {
+                var controlSize = new Size(300, 300);
+                var screenRect = new Rectangle(0, 0, 1920, 1080);
+
+                // top-left
+                yield return new object[]
+                {
+                    controlSize, new Point(400, 500), screenRect,
+                    // expected
+                    new Point(400 - controlSize.Width, 500 - controlSize.Height)
+                };
+
+                // top-right
+                yield return new object[]
+                {
+                    controlSize, new Point(200, 500), screenRect,
+                    // expected
+                    new Point(200, 500 - controlSize.Height)
+                };
+
+                // bottom-right
+                yield return new object[]
+                {
+                    controlSize, new Point(200, 200), screenRect,
+                    // expected
+                    new Point(200, 200)
+                };
+
+                // bottom-left
+                yield return new object[]
+                {
+                    controlSize, new Point(400, 200), screenRect,
+                    // expected
+                    new Point(400 - controlSize.Width, 200)
+                };
+
+                // top-left
+                yield return new object[]
+                {
+                    controlSize, new Point(300, 300), screenRect,
+                    // expected
+                    new Point(0, 0)
+                };
+
+                // top-left
+                yield return new object[]
+                {
+                    controlSize, new Point(screenRect.Width, screenRect.Height), screenRect,
+                    // expected
+                    new Point(screenRect.Width - controlSize.Width, screenRect.Height - controlSize.Height)
+                };
+
+                // edge case control size bigger than screen size
+                yield return new object[]
+                {
+                    controlSize, new Point(0, 0), new Rectangle(0, 0, 200, 200),
+                    // expected
+                    new Point(0, 200 - controlSize.Height)
+                };
+
+                // edge case control height bigger than screen height
+                yield return new object[]
+                {
+                    controlSize, new Point(50, 0), new Rectangle(0, 0, 1920, 200),
+                    // expected
+                    new Point(50, 200 - controlSize.Height)
+                };
+
+                // edge case control width bigger than screen width
+                yield return new object[]
+                {
+                    controlSize, new Point(0, 0), new Rectangle(0, 0, 200, 1080),
+                    // expected
+                    new Point(0, 0)
+                };
+
+                // multi monitor test
+                yield return new object[]
+                {
+                    controlSize, new Point(2500, 500), screenRect,
+                    // expected
+                    new Point(2500 - controlSize.Width, 500 - controlSize.Height)
+                };
+
+                // multi monitor test control bigger than screen
+                yield return new object[]
+                {
+                    controlSize, new Point(1200, 150), new Rectangle(1080, 0, 200, 200),
+                    // expected
+                    new Point(1080, 200 - controlSize.Height)
+                };
+            }
+        }
+    }
+}

--- a/KeeTrayTOTP/KeeTrayTOTP.csproj
+++ b/KeeTrayTOTP/KeeTrayTOTP.csproj
@@ -73,6 +73,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Libraries\DropDownLocationCalculator.cs" />
     <Compile Include="FormAbout.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/KeeTrayTOTP/Libraries/DropDownLocationCalculator.cs
+++ b/KeeTrayTOTP/Libraries/DropDownLocationCalculator.cs
@@ -1,0 +1,120 @@
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace KeeTrayTOTP.Libraries
+{
+    /// <summary>
+    /// Calculator for the location of a dropdown control based on the location of the mouse and screen space available
+    /// </summary>
+    public class DropDownLocationCalculator
+    {
+        private Size _controlSize;
+
+        /// <summary>
+        ///     Initializes a calculator which can calculate the location of a dropdown control based on the location of the mouse
+        ///     and the screen space available.
+        /// </summary>
+        /// <param name="controlSize">The size of the control which will be dropdown-ed</param>
+        public DropDownLocationCalculator(Size controlSize)
+        {
+            _controlSize = controlSize;
+        }
+
+        /// <summary>
+        ///     Calculate the position for a dropdown control based on the given mouse position.
+        ///     The default behavior is to calculate the location for opening the dropdown to the top-left.
+        /// </summary>
+        /// <param name="mousePosition">The position in which the control will be anchored</param>
+        /// <returns>The new location for the control</returns>
+        internal Point CalculateLocationForDropDown(Point mousePosition)
+        {
+            var screen = Screen.FromPoint(mousePosition);
+            return CalculateLocationForDropDown(mousePosition, screen.Bounds);
+        }
+
+        /// <summary>
+        ///     Calculate the position for a dropdown control based on the given mouse position and screen rectangle
+        ///     The default behavior is to calculate the location for opening the dropdown to the top-left.
+        /// </summary>
+        /// <param name="mousePosition">The position in which the control will be anchored</param>
+        /// <param name="screenRect">
+        ///     The screen rectangle which is used for the calculation. This should be the screen on which the
+        ///     control will be opened
+        /// </param>
+        /// <returns></returns>
+        internal Point CalculateLocationForDropDown(Point mousePosition, Rectangle screenRect)
+        {
+            var screenHeight = screenRect.Height;
+            var screenWidth = screenRect.Width;
+
+            // after calculating the offset, the mouse position is relative to the screen containing the cursor
+            // this allows for correct calculations even on multi-monitor systems
+            mousePosition.Offset(-screenRect.X, -screenRect.Y);
+
+            int calculatedX = CalculateX(mousePosition, screenWidth);
+            int calculatedY = CalculateY(mousePosition, screenHeight);
+
+            return new Point(calculatedX + screenRect.X, calculatedY + screenRect.Y);
+        }
+
+        private int CalculateY(Point mousePosition, int screenHeight)
+        {
+            int calculatedY;
+            if (IsEnoughSpaceToTheTop(mousePosition))
+            {
+                calculatedY = mousePosition.Y - _controlSize.Height;
+            }
+            else if (IsEnoughSpaceToTheBottom(mousePosition, screenHeight))
+            {
+                calculatedY = mousePosition.Y;
+            }
+            else
+            {
+                // the control height is higher than the screen height
+                calculatedY = screenHeight - _controlSize.Height;
+            }
+
+            return calculatedY;
+        }
+
+        private int CalculateX(Point mousePosition, int screenWidth)
+        {
+            int calculatedX;
+            if (IsEnoughSpaceToTheLeft(mousePosition))
+            {
+                calculatedX = mousePosition.X - _controlSize.Width;
+            }
+            else if (IsEnoughSpaceToTheRight(mousePosition, screenWidth))
+            {
+                calculatedX = mousePosition.X;
+            }
+            else
+            {
+                // the control width is bigger than the screen width
+                calculatedX = 0;
+            }
+
+            return calculatedX;
+        }
+
+        private bool IsEnoughSpaceToTheLeft(Point mousePosition)
+        {
+            return (mousePosition.X - _controlSize.Width) >= 0;
+        }
+
+        private bool IsEnoughSpaceToTheTop(Point mousePosition)
+        {
+            return (mousePosition.Y - _controlSize.Height) >= 0;
+        }
+
+        private bool IsEnoughSpaceToTheRight(Point mousePosition, int screenWidth)
+        {
+            return (mousePosition.X + _controlSize.Width) <= screenWidth;
+        }
+
+        private bool IsEnoughSpaceToTheBottom(Point mousePosition, int screenHeight)
+        {
+            return (mousePosition.Y + _controlSize.Height) <= screenHeight;
+        }
+    }
+}

--- a/KeeTrayTOTP/TrayTOTP_Plugin.cs
+++ b/KeeTrayTOTP/TrayTOTP_Plugin.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Drawing;
 using System.Windows.Forms;
@@ -267,6 +267,8 @@ namespace KeeTrayTOTP
             _niMenuSeperator = new ToolStripSeparator();
             PluginHost.MainWindow.TrayContextMenu.Items.Insert(1, _niMenuSeperator);
 
+            PluginHost.MainWindow.TrayContextMenu.Opened += TrayContextMenu_Opened;
+
             // Register auto-type function.
             if (PluginHost.CustomConfig.GetBool(setname_bool_AutoType_Enable, true))
             {
@@ -289,6 +291,13 @@ namespace KeeTrayTOTP
             TimeCorrections.AddRangeFromList(PluginHost.CustomConfig.GetString(setname_string_TimeCorrection_List, string.Empty).Split(';').ToList());
 
             return true;
+        }
+
+        private void TrayContextMenu_Opened(object sender, EventArgs e)
+        {
+            var contextMenuStrip = (ContextMenuStrip)sender;
+            var dropDownLocationCalculator = new DropDownLocationCalculator(contextMenuStrip.Size);
+            contextMenuStrip.Location = dropDownLocationCalculator.CalculateLocationForDropDown(Cursor.Position);
         }
 
         /// <summary>

--- a/KeeTrayTOTP/TrayTOTP_Plugin.cs
+++ b/KeeTrayTOTP/TrayTOTP_Plugin.cs
@@ -267,7 +267,7 @@ namespace KeeTrayTOTP
             _niMenuSeperator = new ToolStripSeparator();
             PluginHost.MainWindow.TrayContextMenu.Items.Insert(1, _niMenuSeperator);
 
-            PluginHost.MainWindow.TrayContextMenu.Opened += TrayContextMenu_Opened;
+            PluginHost.MainWindow.TrayContextMenu.Opened += OnTrayContextMenuOpened;
 
             // Register auto-type function.
             if (PluginHost.CustomConfig.GetBool(setname_bool_AutoType_Enable, true))
@@ -293,7 +293,7 @@ namespace KeeTrayTOTP
             return true;
         }
 
-        private void TrayContextMenu_Opened(object sender, EventArgs e)
+        private void OnTrayContextMenuOpened(object sender, EventArgs e)
         {
             var contextMenuStrip = (ContextMenuStrip)sender;
             var dropDownLocationCalculator = new DropDownLocationCalculator(contextMenuStrip.Size);
@@ -892,6 +892,7 @@ namespace KeeTrayTOTP
 
             // Remove Notify Icon menus.
             PluginHost.MainWindow.TrayContextMenu.Opening -= OnNotifyMenuOpening;
+            PluginHost.MainWindow.TrayContextMenu.Opened -= OnTrayContextMenuOpened;
             PluginHost.MainWindow.TrayContextMenu.Items.Remove(_niMenuTitle);
             _niMenuTitle.Dispose();
             foreach (var menu in _niMenuList)


### PR DESCRIPTION
This PR fixes #61

- Calculating the correct position based on the current mouse position. 
- Default opening direction is top-left.
- Added unit tests