### PR TITLE
Fixes deadlock situation if keepass is set to "always on top"

### DIFF
--- a/KeeTrayTOTP/FormAbout.Designer.cs
+++ b/KeeTrayTOTP/FormAbout.Designer.cs
@@ -147,6 +147,7 @@
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "_about form_";
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.FormAbout_FormClosed);
             this.Load += new System.EventHandler(this.FormAbout_Load);
             ((System.ComponentModel.ISupportInitialize)(this.PictureBoxAbout)).EndInit();
             this.ResumeLayout(false);

--- a/KeeTrayTOTP/FormAbout.cs
+++ b/KeeTrayTOTP/FormAbout.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Reflection;
 using System.Windows.Forms;
+using KeePass.UI;
 
 namespace KeeTrayTOTP
 {
@@ -32,6 +33,8 @@ namespace KeeTrayTOTP
         /// <param name="e"></param>
         private void FormAbout_Load(object sender, EventArgs e)
         {
+            GlobalWindowManager.AddWindow(this);
+
             Text = Localization.Strings.About + @" - " + Localization.Strings.TrayTOTPPlugin;
             ListViewAbout.Items[0].SubItems.Add(AssemblyTitle);
             ListViewAbout.Items[1].SubItems.Add(AssemblyCompany);
@@ -150,6 +153,11 @@ namespace KeeTrayTOTP
                 }
                 return ((AssemblyCompanyAttribute)attributes[0]).Company;
             }
+        }
+
+        private void FormAbout_FormClosed(object sender, FormClosedEventArgs e)
+        {
+            GlobalWindowManager.RemoveWindow(this);
         }
     }
 }

--- a/KeeTrayTOTP/FormSettings.Designer.cs
+++ b/KeeTrayTOTP/FormSettings.Designer.cs
@@ -787,6 +787,7 @@
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "_seetings form_";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FormSettings_FormClosing);
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.FormSettings_FormClosed);
             this.Load += new System.EventHandler(this.FormSettings_Load);
             this.TabControlSettings.ResumeLayout(false);
             this.TabPageContextMenus.ResumeLayout(false);

--- a/KeeTrayTOTP/FormSettings.cs
+++ b/KeeTrayTOTP/FormSettings.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Windows.Forms;
+using KeePass.UI;
 
 namespace KeeTrayTOTP
 {
@@ -43,6 +44,8 @@ namespace KeeTrayTOTP
         /// <param name="e"></param>
         private void FormSettings_Load(object sender, EventArgs e)
         {
+            GlobalWindowManager.AddWindow(this);
+
             Text = Localization.Strings.Settings + @" - " + Localization.Strings.TrayTOTPPlugin; // Set form's name using constants.
             Working(true, true); // Set controls depending on the state of action.
             WorkerLoad.RunWorkerAsync(); // Load Settings in form controls.
@@ -478,6 +481,11 @@ namespace KeeTrayTOTP
         private void WorkerReset_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)
         {
             WorkerLoad.RunWorkerAsync("Reset");
+        }
+
+        private void FormSettings_FormClosed(object sender, FormClosedEventArgs e)
+        {
+            GlobalWindowManager.RemoveWindow(this);
         }
     }
 }

--- a/KeeTrayTOTP/FormTimeCorrection.Designer.cs
+++ b/KeeTrayTOTP/FormTimeCorrection.Designer.cs
@@ -229,6 +229,7 @@
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "_time correction_";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FormTimeCorrection_FormClosing);
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.FormTimeCorrection_FormClosed);
             this.Load += new System.EventHandler(this.FormTimeCorrection_Load);
             ((System.ComponentModel.ISupportInitialize)(this.PictureBoxTimeCorrection)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.PictureBoxAbout)).EndInit();

--- a/KeeTrayTOTP/FormTimeCorrection.cs
+++ b/KeeTrayTOTP/FormTimeCorrection.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Windows.Forms;
+using KeePass.UI;
 using KeeTrayTOTP.Libraries;
 
 namespace KeeTrayTOTP
@@ -48,6 +49,8 @@ namespace KeeTrayTOTP
         /// <param name="e"></param>
         private void FormTimeCorrection_Load(object sender, EventArgs e)
         {
+            GlobalWindowManager.AddWindow(this);
+
             Text = Localization.Strings.TimeCorrection + @" - " + Localization.Strings.TrayTOTPPlugin; //Sets the form's display text.
             if (_plugin.PluginHost.MainWindow.ActiveDatabase.IsOpen)
             {
@@ -199,6 +202,11 @@ namespace KeeTrayTOTP
         private void ButtonCancel_Click(object sender, EventArgs e)
         {
             //Dialog Result = Cancel
+        }
+
+        private void FormTimeCorrection_FormClosed(object sender, FormClosedEventArgs e)
+        {
+            GlobalWindowManager.RemoveWindow(this);
         }
     }
 }

--- a/KeeTrayTOTP/SetupTOTP.Designer.cs
+++ b/KeeTrayTOTP/SetupTOTP.Designer.cs
@@ -418,6 +418,7 @@
             this.Name = "SetupTOTP";
             this.ShowInTaskbar = false;
             this.Text = "SetupTOTP";
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.SetupTOTP_FormClosed);
             this.Load += new System.EventHandler(this.SetupTOTP_Load);
             ((System.ComponentModel.ISupportInitialize)(this.PictureBoxAbout)).EndInit();
             this.InfoPanel.ResumeLayout(false);

--- a/KeeTrayTOTP/SetupTOTP.cs
+++ b/KeeTrayTOTP/SetupTOTP.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Forms;
+using KeePass.UI;
 using KeePassLib;
 using KeePassLib.Security;
 
@@ -31,6 +32,8 @@ namespace KeeTrayTOTP
 
         private void SetupTOTP_Load(object sender, EventArgs e)
         {
+            GlobalWindowManager.AddWindow(this);
+
             Text = Localization.Strings.Setup + @" - " + Localization.Strings.TrayTOTPPlugin; //Set form's name using constants.
 
             if (_plugin.SettingsCheck(_entry) || _plugin.SeedCheck(_entry)) //Checks the the totp settings exists.
@@ -228,6 +231,11 @@ namespace KeeTrayTOTP
                 DialogResult = DialogResult.OK;
                 Close();
             }
+        }
+
+        private void SetupTOTP_FormClosed(object sender, FormClosedEventArgs e)
+        {
+            GlobalWindowManager.RemoveWindow(this);
         }
     }
 }

--- a/KeeTrayTOTP/ShowQR.Designer.cs
+++ b/KeeTrayTOTP/ShowQR.Designer.cs
@@ -129,6 +129,7 @@
             this.Name = "ShowQR";
             this.ShowInTaskbar = false;
             this.Text = "ShowQR";
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.ShowQR_FormClosed);
             this.Load += new System.EventHandler(this.ShowQR_Load);
             ((System.ComponentModel.ISupportInitialize)(this.QROutputPicture)).EndInit();
             this.ResumeLayout(false);

--- a/KeeTrayTOTP/ShowQR.cs
+++ b/KeeTrayTOTP/ShowQR.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Forms;
+using KeePass.UI;
 using QRCoder;
 
 namespace KeeTrayTOTP
@@ -15,6 +16,8 @@ namespace KeeTrayTOTP
 
         private void ShowQR_Load(object sender, EventArgs e)
         {
+            GlobalWindowManager.AddWindow(this);
+
             GenerateQRCode();
         }
 
@@ -47,6 +50,11 @@ namespace KeeTrayTOTP
             }
 
             return base.ProcessDialogKey(keyData);
+        }
+
+        private void ShowQR_FormClosed(object sender, FormClosedEventArgs e)
+        {
+            GlobalWindowManager.RemoveWindow(this);
         }
     }
 }


### PR DESCRIPTION
If you enable the keepass setting "always on top" (``View -> Always on Top``) and open the KeeTrayTOTP settings, the settings form is placed under the main keepass window. This creates a deadlock situation. (because it is a dialog and is not reachable)

Solution (this is only necessary if the form is opened as dialog):
- Register forms at opening at the global windows manager of keepass
- Unregister forms on closed