### PR TITLE
Make support link clickable commit #98

### DIFF
--- a/KeeTrayTOTP/FormAbout.Designer.cs
+++ b/KeeTrayTOTP/FormAbout.Designer.cs
@@ -72,6 +72,7 @@
             this.columnHeader2});
             this.ListViewAbout.FullRowSelect = true;
             this.ListViewAbout.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.None;
+            this.ListViewAbout.HideSelection = false;
             this.ListViewAbout.Items.AddRange(new System.Windows.Forms.ListViewItem[] {
             listViewItem1,
             listViewItem2,
@@ -86,6 +87,8 @@
             this.ListViewAbout.TabIndex = 0;
             this.ListViewAbout.UseCompatibleStateImageBehavior = false;
             this.ListViewAbout.View = System.Windows.Forms.View.Details;
+            this.ListViewAbout.MouseClick += new System.Windows.Forms.MouseEventHandler(this.ListViewAbout_MouseClick);
+            this.ListViewAbout.MouseMove += new System.Windows.Forms.MouseEventHandler(this.ListViewAbout_MouseMove);
             // 
             // columnHeader1
             // 

--- a/KeeTrayTOTP/FormAbout.cs
+++ b/KeeTrayTOTP/FormAbout.cs
@@ -41,7 +41,7 @@ namespace KeeTrayTOTP
             ListViewAbout.Items[4].SubItems.Add(SupportUrl.AbsoluteUri);
             LabelCopyright.Text = AssemblyCopyright;
 
-            ChangeToUnderlined(ref ListViewAbout, 4, Color.Blue);
+            SetHyperlinkStyle(4, Color.Blue);
         }
 
         /// <summary>
@@ -169,22 +169,20 @@ namespace KeeTrayTOTP
         {
             var hit = ListViewAbout.HitTest(e.Location);
             if (hit.Item != null && hit.Item == ListViewAbout.Items[4] && hit.SubItem == ListViewAbout.Items[4].SubItems[1])
-            {
-                var url = new Uri(hit.SubItem.Text); 
-                System.Diagnostics.Process.Start(url.ToString());
+            { 
+                System.Diagnostics.Process.Start(SupportUrl.ToString());
             }
         }
         /// <summary>
-        /// Windows Form Row Subitem To Underlined Font.
+        /// Windows Form Row Subitem To Underlined Blue Color Font.
         /// </summary>
-        /// <param name="listView"></param>
         /// <param name="RowIndex"></param>
         /// /// <param name="color"></param>
-        private void ChangeToUnderlined(ref ListView listView, int RowIndex, Color color)
+        private void SetHyperlinkStyle(int RowIndex, Color color)
         {
-            listView.Items[RowIndex].UseItemStyleForSubItems = false;
-            listView.Items[RowIndex].SubItems[1].Font = new Font("Microsoft Sans Serif", 8, FontStyle.Underline);
-            listView.Items[RowIndex].SubItems[1].ForeColor = color;
+            ListViewAbout.Items[RowIndex].UseItemStyleForSubItems = false;
+            ListViewAbout.Items[RowIndex].SubItems[1].Font = new Font("Microsoft Sans Serif", 8, FontStyle.Underline);
+            ListViewAbout.Items[RowIndex].SubItems[1].ForeColor = color;
 
         }
 
@@ -196,9 +194,11 @@ namespace KeeTrayTOTP
         private void ListViewAbout_MouseMove(object sender, MouseEventArgs e)
         {
             var hit = ListViewAbout.HitTest(e.Location);
-            if (hit.Item != ListViewAbout.Items[4]) ListViewAbout.Cursor = Cursors.Default;
-            else if (hit.SubItem != null && hit.SubItem == hit.Item.SubItems[1]) ListViewAbout.Cursor = Cursors.Hand;
-            else ListViewAbout.Cursor = Cursors.Default;
+            if (hit.SubItem != null && hit.SubItem == hit.Item.SubItems[1] && hit.Item == ListViewAbout.Items[4]) {
+                ListViewAbout.Cursor = Cursors.Hand;
+            } else {
+                ListViewAbout.Cursor = Cursors.Default; 
+            }
         }
     }
 }

--- a/KeeTrayTOTP/FormAbout.cs
+++ b/KeeTrayTOTP/FormAbout.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Drawing;
 using System.Reflection;
 using System.Windows.Forms;
 using KeePass.UI;
@@ -39,6 +40,8 @@ namespace KeeTrayTOTP
             ListViewAbout.Items[3].SubItems.Add(AssemblyTrademark);
             ListViewAbout.Items[4].SubItems.Add(SupportUrl.AbsoluteUri);
             LabelCopyright.Text = AssemblyCopyright;
+
+            ChangeToUnderlined(ref ListViewAbout, 4, Color.Blue);
         }
 
         /// <summary>
@@ -155,6 +158,47 @@ namespace KeeTrayTOTP
         private void FormAbout_FormClosed(object sender, FormClosedEventArgs e)
         {
             GlobalWindowManager.RemoveWindow(this);
+        }
+
+        /// <summary>
+        /// Windows Form Mouse Click Handler.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void ListViewAbout_MouseClick(object sender, MouseEventArgs e)
+        {
+            var hit = ListViewAbout.HitTest(e.Location);
+            if (hit.Item != null && hit.Item == ListViewAbout.Items[4] && hit.SubItem == ListViewAbout.Items[4].SubItems[1])
+            {
+                var url = new Uri(hit.SubItem.Text); 
+                System.Diagnostics.Process.Start(url.ToString());
+            }
+        }
+        /// <summary>
+        /// Windows Form Row Subitem To Underlined Font.
+        /// </summary>
+        /// <param name="listView"></param>
+        /// <param name="RowIndex"></param>
+        /// /// <param name="color"></param>
+        private void ChangeToUnderlined(ref ListView listView, int RowIndex, Color color)
+        {
+            listView.Items[RowIndex].UseItemStyleForSubItems = false;
+            listView.Items[RowIndex].SubItems[1].Font = new Font("Microsoft Sans Serif", 8, FontStyle.Underline);
+            listView.Items[RowIndex].SubItems[1].ForeColor = color;
+
+        }
+
+        /// <summary>
+        /// Windows Form Mouse Move Handler.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void ListViewAbout_MouseMove(object sender, MouseEventArgs e)
+        {
+            var hit = ListViewAbout.HitTest(e.Location);
+            if (hit.Item != ListViewAbout.Items[4]) ListViewAbout.Cursor = Cursors.Default;
+            else if (hit.SubItem != null && hit.SubItem == hit.Item.SubItems[1]) ListViewAbout.Cursor = Cursors.Hand;
+            else ListViewAbout.Cursor = Cursors.Default;
         }
     }
 }

--- a/KeeTrayTOTP/FormAbout.resx
+++ b/KeeTrayTOTP/FormAbout.resx
@@ -112,30 +112,30 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="LabelTitleAbout.Locked" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="LabelTitleAbout.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="LabelBannerAbout.Locked" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="LabelBannerAbout.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="ListViewAbout.Locked" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="ListViewAbout.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="ButtonClose.Locked" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="ButtonClose.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="LabelCopyright.Locked" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="LabelCopyright.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="PictureBoxAbout.Locked" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="PictureBoxAbout.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="PictureBoxAbout.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAABGdBTUEAALGPC/xhBQAAE9lJREFUaEO9
@@ -226,7 +226,7 @@
         E/++yZQLCamU4knZrwo5CQkt5Fyuy+dyn9z/E0PlZz/7CziUp2+i86DwAAAAAElFTkSuQmCC
 </value>
   </data>
-  <metadata name="$this.Locked" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="$this.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">


### PR DESCRIPTION
added blue underlined blue font for support link url and made it clickable so that it opens the users default browser at the specified url

fixes #98 