### PR TITLE
Fix a nullreference in QRCodeGenerator

### DIFF
--- a/KeeTrayTOTP.Tests/QRCodeGeneratorTests.cs
+++ b/KeeTrayTOTP.Tests/QRCodeGeneratorTests.cs
@@ -1,0 +1,23 @@
+﻿using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace KeeTrayTOTP.Tests
+{
+    [TestClass]
+    public class QRCodeGeneratorTests
+    {
+        [TestMethod]
+        public void QRCodeGenerator_ShouldGenerateCodeWithValidKeyUrl()
+        {
+            var code = "otpauth://totp/Sample%20Entry%20%232:?secret=JBSWY3DPEHPK3PXP&issuer=Sample%20Entry%20%232";
+            using (var generator = new QRCoder.QRCodeGenerator())
+            {
+                var act = generator.CreateQrCode(code);
+
+                act.Should().NotBeNull();
+                act.Version.Should().Be(8);
+                act.ModuleMatrix.Should().HaveCount(57);
+            }
+        }
+    }
+}

--- a/KeeTrayTOTP/Libraries/QRCoder/QRCodeGenerator.cs
+++ b/KeeTrayTOTP/Libraries/QRCoder/QRCodeGenerator.cs
@@ -830,12 +830,12 @@ namespace QRCoder
         private int GetVersion(int length, EncodingMode encMode, ErrorCorrectionLevel errorCorrectionLevel)
         {
             return this.capacityTable
-               .Where(x => x.Details.Any(y => y.ErrorCorrectionLevel == errorCorrectionLevel && y.CapacityDict[encMode] >= Convert.ToInt32(length)))
-               .Select(x => new
-               {
-                   version = x.Version,
-                   capacity = x.Details.Single(y => y.ErrorCorrectionLevel == errorCorrectionLevel).CapacityDict[encMode]
-               }).Min(x => x.version);
+                .Where(x => x.Details.Any(y => y.ErrorCorrectionLevel == errorCorrectionLevel && y.CapacityDict[encMode] >= Convert.ToInt32(length)))
+                .Select(x => new
+                {
+                    version = x.Version,
+                    capacity = x.Details.Single(y => y.ErrorCorrectionLevel == errorCorrectionLevel).CapacityDict[encMode]
+                }).Min(x => x.version);
         }
 
         private EncodingMode GetEncodingFromPlaintext(string plainText, bool forceUtf8)

--- a/KeeTrayTOTP/Libraries/QRCoder/QRCodeGenerator.cs
+++ b/KeeTrayTOTP/Libraries/QRCoder/QRCodeGenerator.cs
@@ -63,7 +63,7 @@ namespace QRCoder
             this.CreateAlignmentPatternTable();
         }
 
-        public QRCodeData CreateQrCode(string plainText, ErrorCorrectionLevel eccLevel = QRCodeGenerator.ErrorCorrectionLevel.Q, bool forceUtf8 = false, bool utf8BOM = false, EciMode eciMode = EciMode.Default, int requestedVersion = -1)
+        public QRCodeData CreateQrCode(string plainText, ErrorCorrectionLevel eccLevel = ErrorCorrectionLevel.Q, bool forceUtf8 = false, bool utf8BOM = false, EciMode eciMode = EciMode.Default, int requestedVersion = -1)
         {
             EncodingMode encoding = GetEncodingFromPlaintext(plainText, forceUtf8);
             var codedText = this.PlainTextToBinary(plainText, encoding, eciMode, utf8BOM, forceUtf8);
@@ -569,6 +569,47 @@ namespace QRCoder
 
             private static class MaskPattern
             {
+                // NOTE: Methods are invoked via reflection (typeof(MaskPattern).GetMethods()))
+                public static bool Pattern1(int x, int y)
+                {
+                    return (x + y) % 2 == 0;
+                }
+
+                public static bool Pattern2(int x, int y)
+                {
+                    return y % 2 == 0;
+                }
+
+                public static bool Pattern3(int x, int y)
+                {
+                    return x % 3 == 0;
+                }
+
+                public static bool Pattern4(int x, int y)
+                {
+                    return (x + y) % 3 == 0;
+                }
+
+                public static bool Pattern5(int x, int y)
+                {
+                    return ((int)(Math.Floor(y / 2d) + Math.Floor(x / 3d)) % 2) == 0;
+                }
+
+                public static bool Pattern6(int x, int y)
+                {
+                    return ((x * y) % 2) + ((x * y) % 3) == 0;
+                }
+
+                public static bool Pattern7(int x, int y)
+                {
+                    return (((x * y) % 2) + ((x * y) % 3)) % 2 == 0;
+                }
+
+                public static bool Pattern8(int x, int y)
+                {
+                    return (((x + y) % 2) + ((x * y) % 3)) % 2 == 0;
+                }
+
                 public static int Score(ref QRCodeData qrCode)
                 {
                     int score1 = 0,
@@ -789,12 +830,12 @@ namespace QRCoder
         private int GetVersion(int length, EncodingMode encMode, ErrorCorrectionLevel errorCorrectionLevel)
         {
             return this.capacityTable
-                .Where(x => x.Details.Any(y => y.ErrorCorrectionLevel == errorCorrectionLevel && y.CapacityDict[encMode] >= Convert.ToInt32(length)))
-                .Select(x => new
-                {
-                    version = x.Version,
-                    capacity = x.Details.Single(y => y.ErrorCorrectionLevel == errorCorrectionLevel).CapacityDict[encMode]
-                }).Min(x => x.version);
+               .Where(x => x.Details.Any(y => y.ErrorCorrectionLevel == errorCorrectionLevel && y.CapacityDict[encMode] >= Convert.ToInt32(length)))
+               .Select(x => new
+               {
+                   version = x.Version,
+                   capacity = x.Details.Single(y => y.ErrorCorrectionLevel == errorCorrectionLevel).CapacityDict[encMode]
+               }).Min(x => x.version);
         }
 
         private EncodingMode GetEncodingFromPlaintext(string plainText, bool forceUtf8)

--- a/KeeTrayTOTP/ShowQR.cs
+++ b/KeeTrayTOTP/ShowQR.cs
@@ -27,8 +27,6 @@ namespace KeeTrayTOTP
 
         private void GenerateQRCode()
         {
-      
-
             var code = string.Format("otpauth://totp/{0}:{1}?secret={2}&issuer={0}", Uri.EscapeDataString(IssuerText.Text), Uri.EscapeDataString(UsernameText.Text), this.seed);
 
             using (var qrGenerator = new QRCodeGenerator())


### PR DESCRIPTION
Removed a bit too many methods in the `QRCodeGenerator` that were invoked via reflection. Added a test to reproduce and then worked towards a fix. Fixes #119 