### PR TITLE
Removed a .NET Framework 4.5 type to fully support .NET Framework 4.0

### DIFF
--- a/KeeTrayTOTP/KeeTrayTOTP.csproj
+++ b/KeeTrayTOTP/KeeTrayTOTP.csproj
@@ -9,7 +9,7 @@
     <PlgxConfiguration>
       <Prerequisites>
         <KeePassVersion>2.31</KeePassVersion>
-        <DotNetVersion>3.5</DotNetVersion>
+        <DotNetVersion>4.0</DotNetVersion>
       </Prerequisites>
     </PlgxConfiguration>
   </PropertyGroup>

--- a/KeeTrayTOTP/TrayTOTP_Plugin.cs
+++ b/KeeTrayTOTP/TrayTOTP_Plugin.cs
@@ -70,7 +70,7 @@ namespace KeeTrayTOTP
         /// </summary>
         internal const int setstat_int_EntryList_RefreshRate = 300;
         internal const int setstat_trim_text_length = 25;
-        internal IReadOnlyList<string> setstat_allowed_lengths = new ReadOnlyCollection<string>(new[] { "6", "7", "8", "S" });
+        internal readonly ReadOnlyCollection<string> setstat_allowed_lengths = new ReadOnlyCollection<string>(new[] { "6", "7", "8", "S" });
 
         /// <summary>
         /// Form Help Global Reference.


### PR DESCRIPTION
- Removed the IReadOnlyList type.
- Bumped the required plgx DotNetVersion to 4.0.

This fixes #99 and maybe #124

