### PR TITLE
Tweak base32 implementation

### DIFF
--- a/KeeTrayTOTP.Tests/Base32Tests.cs
+++ b/KeeTrayTOTP.Tests/Base32Tests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using KeeTrayTOTP.Libraries;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -9,6 +10,8 @@ namespace KeeTrayTOTP.Tests
     [TestClass]
     public class Base32Tests
     {
+        private const string InvalidSeed = "MZXW6!YTBOI======!";
+
         [DataTestMethod]
         [DynamicData(nameof(GetBase32Data), DynamicDataSourceType.Method)]
         public void Encode_ShouldWorkOnRfc4648TestCases(Base32TestCase testCase)
@@ -31,15 +34,41 @@ namespace KeeTrayTOTP.Tests
 
         [DataTestMethod]
         [DynamicData(nameof(GetBase32Data), DynamicDataSourceType.Method)]
-        public void ExtIsBase32_ShouldReturnTrueFor(Base32TestCase testCase)
+        public void IsBase32Out_ShouldReturnTrueFor(Base32TestCase testCase)
         {
-            var actual = testCase.Encoded.ExtIsBase32(out string invalidChars);
+            var actual = testCase.Encoded.IsBase32(out string invalidChars);
 
             actual.Should().BeTrue();
             invalidChars.Should().BeNullOrEmpty();
         }
 
-        /// <summary>
+        [DataTestMethod]
+        [DynamicData(nameof(GetBase32Data), DynamicDataSourceType.Method)]
+        public void IsBase32_ShouldReturnTrueFor(Base32TestCase testCase)
+        {
+            var actual = testCase.Encoded.IsBase32();
+
+            actual.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void Decode_ShouldThrowWithInvalidSeed()
+        {
+            Action act = () => Base32.Decode(InvalidSeed);
+
+            act.Should().Throw<ArgumentException>().WithMessage("Base32 contains illegal characters.");
+        }
+
+        [TestMethod]
+        public void ExtIsBase32_ShouldReturnFalseWithInvalidChars()
+        {
+            var actual = InvalidSeed.IsBase32(out string invalidChars);
+
+            actual.Should().BeFalse();
+            invalidChars.Should().Be("!======!");
+        }
+
+                /// <summary>
         /// Testcases were taken from <see cref="https://tools.ietf.org/html/rfc4648"/>
         /// </summary>
         public static IEnumerable<object[]> GetBase32Data()

--- a/KeeTrayTOTP.Tests/Base32Tests.cs
+++ b/KeeTrayTOTP.Tests/Base32Tests.cs
@@ -1,0 +1,80 @@
+﻿using FluentAssertions;
+using KeeTrayTOTP.Libraries;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Text;
+
+namespace KeeTrayTOTP.Tests
+{
+    [TestClass]
+    public class Base32Tests
+    {
+        [DataTestMethod]
+        [DynamicData(nameof(GetBase32Data), DynamicDataSourceType.Method)]
+        public void Encode_ShouldWorkOnRfc4648TestCases(Base32TestCase testCase)
+        {
+            var actual = Base32.Encode(Encoding.UTF8.GetBytes(testCase.Decoded));
+
+            actual.Should().Be(testCase.Encoded);
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(GetBase32Data), DynamicDataSourceType.Method)]
+        public void Decode_ShouldWorkOnRfc4648TestCases(Base32TestCase testCase)
+        {
+            var actual = Base32.Decode(testCase.Encoded);
+
+            var actualString = Encoding.UTF8.GetString(actual);
+
+            actualString.Should().Be(testCase.Decoded);
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(GetBase32Data), DynamicDataSourceType.Method)]
+        public void ExtIsBase32_ShouldReturnTrueFor(Base32TestCase testCase)
+        {
+            var actual = testCase.Encoded.ExtIsBase32(out string invalidChars);
+
+            actual.Should().BeTrue();
+            invalidChars.Should().BeNullOrEmpty();
+        }
+
+        /// <summary>
+        /// Testcases were taken from <see cref="https://tools.ietf.org/html/rfc4648"/>
+        /// </summary>
+        public static IEnumerable<object[]> GetBase32Data()
+        {
+            yield return new object[] { new Base32TestCase("", "") };
+            yield return new object[] { new Base32TestCase("f", "MY======") };
+            yield return new object[] { new Base32TestCase("fo", "MZXQ====") };
+            yield return new object[] { new Base32TestCase("foo", "MZXW6===") };
+            yield return new object[] { new Base32TestCase("foob", "MZXW6YQ=") };
+            yield return new object[] { new Base32TestCase("fooba", "MZXW6YTB") };
+            yield return new object[] { new Base32TestCase("foobar", "MZXW6YTBOI======") };
+        }
+
+        public sealed class Base32TestCase
+        {
+            public Base32TestCase(string decoded, string encoded)
+            {
+                this.Decoded = decoded;
+                this.Encoded = encoded;
+            }
+
+            /// <summary>
+            /// Input for Encoding, expected Output for Decoding
+            /// </summary>
+            public string Decoded { get; }
+
+            /// <summary>
+            /// String in Base32 encoding
+            /// </summary>
+            public string Encoded { get; }
+
+            public override string ToString()
+            {
+                return $"Decoded = {Decoded}, Encoded = {Encoded}";
+            }
+        }
+    }
+}

--- a/KeeTrayTOTP.Tests/Base32Tests.cs
+++ b/KeeTrayTOTP.Tests/Base32Tests.cs
@@ -10,7 +10,7 @@ namespace KeeTrayTOTP.Tests
     [TestClass]
     public class Base32Tests
     {
-        private const string InvalidSeed = "MZXW6!YTBOI======!";
+        private const string InvalidSeed = "MZXW6=YTBOI!===!";
 
         [DataTestMethod]
         [DynamicData(nameof(GetBase32Data), DynamicDataSourceType.Method)]
@@ -51,6 +51,13 @@ namespace KeeTrayTOTP.Tests
             actual.Should().BeTrue();
         }
 
+        [DataTestMethod]
+        [DynamicData(nameof(GetBase32Data), DynamicDataSourceType.Method)]
+        public void HasInvalidPadding_ShouldReturnFalseFor(Base32TestCase testCase)
+        {
+            Base32.HasInvalidPadding(testCase.Encoded).Should().BeFalse();
+        }
+
         [TestMethod]
         public void Decode_ShouldThrowWithInvalidSeed()
         {
@@ -63,12 +70,17 @@ namespace KeeTrayTOTP.Tests
         public void ExtIsBase32_ShouldReturnFalseWithInvalidChars()
         {
             var actual = InvalidSeed.IsBase32(out string invalidChars);
-
             actual.Should().BeFalse();
-            invalidChars.Should().Be("!======!");
+            invalidChars.Should().Be("=!");
         }
 
-                /// <summary>
+        [TestMethod]
+        public void HasInvalidPadding_ShouldReturnTrueWhenNotPadding()
+        {
+            Base32.HasInvalidPadding(InvalidSeed).Should().BeTrue();
+        }
+
+        /// <summary>
         /// Testcases were taken from <see cref="https://tools.ietf.org/html/rfc4648"/>
         /// </summary>
         public static IEnumerable<object[]> GetBase32Data()

--- a/KeeTrayTOTP.Tests/TrayTOTP_ColumnproviderTests.cs
+++ b/KeeTrayTOTP.Tests/TrayTOTP_ColumnproviderTests.cs
@@ -16,7 +16,7 @@ namespace KeeTrayTOTP.Tests
         private readonly KeeTrayTOTPExt _plugin;
         private readonly IPluginHost _pluginHost;
 
-        const string InvalidSeed = "C5CYMIHWQUUZMKUGZHGEOSJSQDE4L===";
+        const string InvalidSeed = "C5CYMIHWQUUZMKUGZHGEOSJSQDE4L===!";
         const string ValidSeed = "JBSWY3DPEHPK3PXP";
         const string ValidSettings = "30;6";
 

--- a/KeeTrayTOTP/Libraries/Base32.cs
+++ b/KeeTrayTOTP/Libraries/Base32.cs
@@ -21,6 +21,8 @@
 // THE SOFTWARE.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace KeeTrayTOTP.Libraries
 {
@@ -121,7 +123,7 @@ namespace KeeTrayTOTP.Libraries
                 return new byte[0];
             }
 
-            var unpaddedBase32 = base32.ToUpperInvariant().TrimEnd(PaddingCharacter);
+            var unpaddedBase32 = GetUnpaddedBase32(base32);
 
             foreach (var c in unpaddedBase32)
             {
@@ -161,6 +163,29 @@ namespace KeeTrayTOTP.Libraries
             }
 
             return outputBuffer;
+        }
+
+        public static bool IsBase32(this string input)
+        {
+            return GetUnpaddedBase32(input).All(EncodingChars.Contains);
+        }
+
+        public static bool IsBase32(this string input, out string invalidCharacters)
+        {
+            invalidCharacters = null;
+            foreach (var c in GetUnpaddedBase32(input))
+            {
+                if (!EncodingChars.Contains(c))
+                {
+                    invalidCharacters += c.ToString();
+                }
+            }
+
+            return invalidCharacters == null;
+        }
+        private static string GetUnpaddedBase32(string input)
+        {
+            return input.ToUpperInvariant().TrimEnd(PaddingCharacter);
         }
     }
 }

--- a/KeeTrayTOTP/Libraries/Base32.cs
+++ b/KeeTrayTOTP/Libraries/Base32.cs
@@ -165,6 +165,11 @@ namespace KeeTrayTOTP.Libraries
             return outputBuffer;
         }
 
+        public static bool HasInvalidPadding(string input)
+        {
+            return GetUnpaddedBase32(input).Contains(PaddingCharacter);
+        }
+
         public static bool IsBase32(this string input)
         {
             return GetUnpaddedBase32(input).All(EncodingChars.Contains);
@@ -172,17 +177,20 @@ namespace KeeTrayTOTP.Libraries
 
         public static bool IsBase32(this string input, out string invalidCharacters)
         {
-            invalidCharacters = null;
+            var hashSet = new HashSet<char>();
             foreach (var c in GetUnpaddedBase32(input))
             {
                 if (!EncodingChars.Contains(c))
                 {
-                    invalidCharacters += c.ToString();
+                    hashSet.Add(c);
                 }
             }
 
-            return invalidCharacters == null;
+            invalidCharacters = new string(hashSet.ToArray());
+
+            return hashSet.Count == 0;
         }
+
         private static string GetUnpaddedBase32(string input)
         {
             return input.ToUpperInvariant().TrimEnd(PaddingCharacter);

--- a/KeeTrayTOTP/Libraries/Base32.cs
+++ b/KeeTrayTOTP/Libraries/Base32.cs
@@ -1,9 +1,31 @@
-﻿using System;
+﻿// Taken from https://raw.githubusercontent.com/telehash/telehash.net/master/Telehash.Net/Base32.cs
+//
+// Copyright(c) 2015 Thomas Muldowney
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
 
 namespace KeeTrayTOTP.Libraries
 {
     /// <summary>
-    /// Utility to deal with Base32 encoding and decoding.
+    /// Utility to deal with Base32 encoding and decoding
     /// </summary>
     /// <remarks>
     /// http://tools.ietf.org/html/rfc4648
@@ -11,11 +33,11 @@ namespace KeeTrayTOTP.Libraries
     public static class Base32
     {
         /// <summary>
-        /// The number of bits in a base32 encoded character.
+        /// The number of bits in a base32 encoded character
         /// </summary>
         private const int EncodedBitCount = 5;
         /// <summary>
-        /// The number of bits in a byte.
+        /// The number of bits in a byte
         /// </summary>
         private const int ByteBitCount = 8;
         /// <summary>
@@ -25,26 +47,30 @@ namespace KeeTrayTOTP.Libraries
         /// </summary>
         private const string EncodingChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
         /// <summary>
-        /// Takes a block of data and converts it to a base 32 encoded string.
+        /// The rfc defines '=' as the padding character
         /// </summary>
-        /// <param name="data">Input data.</param>
-        /// <returns>base 32 string.</returns>
+        private const char PaddingCharacter = '=';
+        /// <summary>
+        /// Takes a block of data and converts it to a base 32 encoded string
+        /// </summary>
+        /// <param name="data">Input data</param>
+        /// <returns>base 32 string</returns>
         public static string Encode(byte[] data)
         {
             if (data == null)
             {
-                throw new ArgumentNullException();
+                throw new ArgumentNullException("data");
             }
 
             if (data.Length == 0)
             {
-                throw new ArgumentNullException();
+                return string.Empty;
             }
 
             // The output character count is calculated in 40 bit blocks.  That is because the least
             // common blocks size for both binary (8 bit) and base 32 (5 bit) is 40.  Padding must be used
             // to fill in the difference.
-            int outputCharacterCount = (int)Math.Ceiling(data.Length / (decimal)EncodedBitCount) * ByteBitCount;
+            var outputCharacterCount = (int)decimal.Ceiling(data.Length / (decimal)EncodedBitCount) * ByteBitCount;
             char[] outputBuffer = new char[outputCharacterCount];
 
             byte workingValue = 0;
@@ -67,7 +93,7 @@ namespace KeeTrayTOTP.Libraries
                 workingValue = (byte)((workingByte << remainingBits) & 31);
             }
 
-            // If we didn't finish, write the last current working char.
+            // If we didn't finish, write the last current working char
             if (currentPosition != outputCharacterCount)
             {
                 outputBuffer[currentPosition++] = EncodingChars[workingValue];
@@ -77,8 +103,7 @@ namespace KeeTrayTOTP.Libraries
             // Since the outputCharacterCount does account for the paddingCharacters, fill it out.
             while (currentPosition < outputCharacterCount)
             {
-                // The RFC defined paddinc char is '='.
-                outputBuffer[currentPosition++] = '=';
+                outputBuffer[currentPosition++] = PaddingCharacter;
             }
 
             return new string(outputBuffer);
@@ -93,10 +118,11 @@ namespace KeeTrayTOTP.Libraries
         {
             if (string.IsNullOrEmpty(base32))
             {
-                throw new ArgumentNullException();
+                return new byte[0];
             }
 
-            var unpaddedBase32 = base32.ToUpperInvariant().TrimEnd('=');
+            var unpaddedBase32 = base32.ToUpperInvariant().TrimEnd(PaddingCharacter);
+
             foreach (var c in unpaddedBase32)
             {
                 if (EncodingChars.IndexOf(c) < 0)

--- a/KeeTrayTOTP/Localization/Strings.Designer.cs
+++ b/KeeTrayTOTP/Localization/Strings.Designer.cs
@@ -331,6 +331,15 @@ namespace KeeTrayTOTP.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Padding (=) can only appear at the end!.
+        /// </summary>
+        internal static string SetupInvalidPadding {
+            get {
+                return ResourceManager.GetString("SetupInvalidPadding", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid URL!.
         /// </summary>
         internal static string SetupInvalidUrl {

--- a/KeeTrayTOTP/Localization/Strings.resx
+++ b/KeeTrayTOTP/Localization/Strings.resx
@@ -210,6 +210,9 @@
   <data name="SetupInvalidCharacter" xml:space="preserve">
     <value>Invalid character</value>
   </data>
+  <data name="SetupInvalidPadding" xml:space="preserve">
+    <value>Padding (=) can only appear at the end!</value>
+  </data>
   <data name="SetupInvalidUrl" xml:space="preserve">
     <value>Invalid URL!</value>
   </data>

--- a/KeeTrayTOTP/SetupTOTP.cs
+++ b/KeeTrayTOTP/SetupTOTP.cs
@@ -103,9 +103,13 @@ namespace KeeTrayTOTP
             {
                 ErrorProviderSetup.SetError(TextBoxSeedSetup, Localization.Strings.SetupSeedCantBeEmpty);
             }
-            else if (!TextBoxSeedSetup.Text.ExtWithoutSpaces().IsBase32(out invalidBase32Chars)) // TODO: Add support to other known formats
+            else if (Base32.HasInvalidPadding(TextBoxSeedSetup.Text.ExtWithoutSpaces()))
             {
-                ErrorProviderSetup.SetError(TextBoxSeedSetup, Localization.Strings.SetupInvalidCharacter + "(" + invalidBase32Chars + ")!");
+                ErrorProviderSetup.SetError(TextBoxSeedSetup, Localization.Strings.SetupInvalidPadding);
+            }
+            else if (!TextBoxSeedSetup.Text.ExtWithoutSpaces().IsBase32(out invalidBase32Chars))
+            {
+                ErrorProviderSetup.SetError(TextBoxSeedSetup, Localization.Strings.SetupInvalidCharacter + "(" + invalidBase32Chars + ")");
             }
             else
             {

--- a/KeeTrayTOTP/SetupTOTP.cs
+++ b/KeeTrayTOTP/SetupTOTP.cs
@@ -3,6 +3,7 @@ using System.Windows.Forms;
 using KeePass.UI;
 using KeePassLib;
 using KeePassLib.Security;
+using KeeTrayTOTP.Libraries;
 
 namespace KeeTrayTOTP
 {
@@ -102,7 +103,7 @@ namespace KeeTrayTOTP
             {
                 ErrorProviderSetup.SetError(TextBoxSeedSetup, Localization.Strings.SetupSeedCantBeEmpty);
             }
-            else if (!TextBoxSeedSetup.Text.ExtWithoutSpaces().ExtIsBase32(out invalidBase32Chars)) // TODO: Add support to other known formats
+            else if (!TextBoxSeedSetup.Text.ExtWithoutSpaces().IsBase32(out invalidBase32Chars)) // TODO: Add support to other known formats
             {
                 ErrorProviderSetup.SetError(TextBoxSeedSetup, Localization.Strings.SetupInvalidCharacter + "(" + invalidBase32Chars + ")!");
             }

--- a/KeeTrayTOTP/TrayTOTP_Extensions.cs
+++ b/KeeTrayTOTP/TrayTOTP_Extensions.cs
@@ -1,4 +1,5 @@
 ﻿using KeePassLib;
+using KeeTrayTOTP.Libraries;
 using System;
 
 namespace KeeTrayTOTP
@@ -124,7 +125,7 @@ namespace KeeTrayTOTP
             invalidChars = null;
             try
             {
-                foreach (var currentChar in extension)
+                foreach (var currentChar in extension.TrimEnd('='))
                 {
                     var currentCharValue = char.GetNumericValue(currentChar);
                     if (char.IsLetter(currentChar))

--- a/KeeTrayTOTP/TrayTOTP_Extensions.cs
+++ b/KeeTrayTOTP/TrayTOTP_Extensions.cs
@@ -114,38 +114,6 @@ namespace KeeTrayTOTP
             return string.Empty;
         }
 
-        /// <summary>
-        /// Makes sure the string provided as a Seed is Base32. Invalid characters are available as out string.
-        /// </summary>
-        /// <param name="extension">Current string.</param>
-        /// <param name="invalidChars">Invalid characters.</param>
-        /// <returns>Validity of the string's characters for Base32 format.</returns>
-        internal static bool ExtIsBase32(this string extension, out string invalidChars)
-        {
-            invalidChars = null;
-            try
-            {
-                foreach (var currentChar in extension.TrimEnd('='))
-                {
-                    var currentCharValue = char.GetNumericValue(currentChar);
-                    if (char.IsLetter(currentChar))
-                    {
-                        continue;
-                    }
-                    if (char.IsDigit(currentChar) && (currentCharValue > 1) && (currentCharValue < 8))
-                    {
-                        continue;
-                    }
-                    invalidChars = (invalidChars + currentCharValue.ToString().ExtWithSpaceBefore()).Trim();
-                }
-            }
-            catch (Exception)
-            {
-                invalidChars = Localization.Strings.Error;
-            }
-            return invalidChars == null;
-        }
-
         internal static bool IsExpired(this PwEntry passwordEntry)
         {
             if (!passwordEntry.Expires)

--- a/KeeTrayTOTP/TrayTOTP_Plugin.cs
+++ b/KeeTrayTOTP/TrayTOTP_Plugin.cs
@@ -800,8 +800,7 @@ namespace KeeTrayTOTP
         /// <returns>Validity of the Seed's characters for Base32 format.</returns>
         internal bool SeedValidate(PwEntry passwordEntry)
         {
-            string invalidCharacters;
-            return SeedGet(passwordEntry).ReadString().ExtWithoutSpaces().ExtIsBase32(out invalidCharacters);
+            return SeedGet(passwordEntry).ReadString().ExtWithoutSpaces().IsBase32();
         }
 
         /// <summary>
@@ -812,7 +811,7 @@ namespace KeeTrayTOTP
         /// <returns>Validity of the Seed's characters.</returns>
         internal bool SeedValidate(PwEntry passwordEntry, out string invalidCharacters)
         {
-            return SeedGet(passwordEntry).ReadString().ExtWithoutSpaces().ExtIsBase32(out invalidCharacters);
+            return SeedGet(passwordEntry).ReadString().ExtWithoutSpaces().IsBase32(out invalidCharacters);
         }
 
         /// <summary>

--- a/KeeTrayTOTP/TrayTOTP_Plugin.cs
+++ b/KeeTrayTOTP/TrayTOTP_Plugin.cs
@@ -391,7 +391,7 @@ namespace KeeTrayTOTP
             }
 
             var rawSeed = this.SeedGet(entry).ReadString();
-            var cleanSeed = Regex.Replace(rawSeed, @"\s+", "");
+            var cleanSeed = Regex.Replace(rawSeed, @"\s+", "").TrimEnd('=');
             var issuer = entry.Strings.Get("Title").ReadString();
             var username = entry.Strings.Get("UserName").ReadString();
             UIUtil.ShowDialogAndDestroy(new ShowQR(cleanSeed, issuer, username));

--- a/KeeTrayTOTP/TrayTOTP_Plugin.cs
+++ b/KeeTrayTOTP/TrayTOTP_Plugin.cs
@@ -808,11 +808,11 @@ namespace KeeTrayTOTP
         /// Validates the entry's Seed making sure it's a valid Base32 string. Invalid characters are available as out string.
         /// </summary>
         /// <param name="passwordEntry">Password Entry.</param>
-        /// <param name="invalidChars">Password Entry.</param>
+        /// <param name="invalidCharacters">Password Entry.</param>
         /// <returns>Validity of the Seed's characters.</returns>
-        internal bool SeedValidate(PwEntry passwordEntry, out string invalidChars)
+        internal bool SeedValidate(PwEntry passwordEntry, out string invalidCharacters)
         {
-            return SeedGet(passwordEntry).ReadString().ExtWithoutSpaces().ExtIsBase32(out invalidChars);
+            return SeedGet(passwordEntry).ReadString().ExtWithoutSpaces().ExtIsBase32(out invalidCharacters);
         }
 
         /// <summary>


### PR DESCRIPTION
- Tracked down original implementation of Base32.cs.
  * Applied their license
  * Applied our project formatting.
  * Fixed a violation of the RFC with empty strings
- Tweak ExtIsBase32, so that trailing = (padding) is allowed

When done, should close #130 