### PR TITLE
Add Code Coverage to SonarQube and adjust Quality Gate

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,7 +36,7 @@ jobs:
       run: dotnet test --no-build --collect:"XPlat Code Coverage" --settings coverlet.runsettings
 
     - name: Copy coverage file to root for SonarQube
-      run:  cp -Path (gci -Path KeeTrayTOTP.Tests -Recurse -Force -Name coverage.opencover.xml) -Destination coverage.opencover.xml
+      run: cp -Path ("KeeTrayTOTP.Tests\TestResults\" + (gci -Path KeeTrayTOTP.Tests\TestResults -Recurse -Force -Name coverage.opencover.xml)) -Destination coverage.opencover.xml
 
     - name: SonarScanner End
       run: dotnet sonarscanner end

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,15 +26,18 @@ jobs:
       run: dotnet tool install --global dotnet-sonarscanner
       
     - name: SonarScanner Begin
-      run: dotnet sonarscanner begin /k:KeeTrayTOTP_KeeTrayTOTP /o:keetraytotp /d:sonar.host.url="https://sonarcloud.io"
+      run: dotnet sonarscanner begin /k:KeeTrayTOTP_KeeTrayTOTP /o:keetraytotp /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths="coverage.opencover.xml"
 
     - name: MSBuild
       run: msbuild KeeTrayTOTP.sln /m
 
     - name: Run tests
       # It looks like the dotnet CLI can no longer build net45 projects? see https://github.com/microsoft/msbuild/issues/4704
-      run: dotnet test --no-build --collect:"XPlat Code Coverage"
-      
+      run: dotnet test --no-build --collect:"XPlat Code Coverage" --settings coverlet.runsettings
+
+    - name: Copy coverage file to root
+      run: for /f %a in ('dir /b /s coverage.opencover.xml ^| findstr "TestResults"') do xcopy "%a" . /i
+
     - name: SonarScanner End
       run: dotnet sonarscanner end
       env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,7 +35,7 @@ jobs:
       # It looks like the dotnet CLI can no longer build net45 projects? see https://github.com/microsoft/msbuild/issues/4704
       run: dotnet test --no-build --collect:"XPlat Code Coverage" --settings coverlet.runsettings
 
-    - name: Copy coverage file to root for SonarQube
+    - name: Copy coverage file to root for SonarQube. SonarQube currently does not support wildcards, and the coverage file ends up in a new folder with a random name.
       run: cp -Path ("KeeTrayTOTP.Tests\TestResults\" + (gci -Path KeeTrayTOTP.Tests\TestResults -Recurse -Force -Name coverage.opencover.xml)) -Destination coverage.opencover.xml
 
     - name: SonarScanner End

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Run tests
       # It looks like the dotnet CLI can no longer build net45 projects? see https://github.com/microsoft/msbuild/issues/4704
-      run: dotnet test --no-build
+      run: dotnet test --no-build --collect:"XPlat Code Coverage"
       
     - name: SonarScanner End
       run: dotnet sonarscanner end

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,8 +35,8 @@ jobs:
       # It looks like the dotnet CLI can no longer build net45 projects? see https://github.com/microsoft/msbuild/issues/4704
       run: dotnet test --no-build --collect:"XPlat Code Coverage" --settings coverlet.runsettings
 
-    - name: Copy coverage file to root
-      run: for /f %a in ('dir /b /s coverage.opencover.xml ^| findstr "TestResults"') do xcopy "%a" . /i
+    - name: Copy coverage file to root for SonarQube
+      run:  cp -Path (gci -Path KeeTrayTOTP.Tests -Recurse -Force -Name coverage.opencover.xml) -Destination coverage.opencover.xml
 
     - name: SonarScanner End
       run: dotnet sonarscanner end

--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,6 @@ FakesAssemblies/
 
 # Visual Studio 6 workspace options file
 *.opt
+
+# Code coverage
+coverage.opencover.xml

--- a/KeeTrayTOTP.Tests/KeeTrayTOTP.Tests.csproj
+++ b/KeeTrayTOTP.Tests/KeeTrayTOTP.Tests.csproj
@@ -14,6 +14,10 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="1.2.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />

--- a/KeeTrayTOTP/SetupTOTP.cs
+++ b/KeeTrayTOTP/SetupTOTP.cs
@@ -212,20 +212,14 @@ namespace KeeTrayTOTP
         /// <param name="e"></param>
         private void ButtonDelete_Click(object sender, EventArgs e)
         {
-            //if (_plugin.SettingsCheck(entry) || _plugin.SeedCheck(entry))
             if (MessageBox.Show(Localization.Strings.SetupMessageAskDeleteCurrentEntry, Localization.Strings.TrayTOTPPlugin, MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.Yes)
             {
-                try
-                {
-                    _entry.CreateBackup(_plugin.PluginHost.MainWindow.ActiveDatabase);
-                    _entry.Strings.Remove(_plugin.PluginHost.CustomConfig.GetString(KeeTrayTOTPExt.setname_string_TOTPSeed_StringName, Localization.Strings.TOTPSeed));
-                    _entry.Strings.Remove(_plugin.PluginHost.CustomConfig.GetString(KeeTrayTOTPExt.setname_string_TOTPSettings_StringName, Localization.Strings.TOTPSettings));
-                    _entry.Touch(true);
-                    _plugin.PluginHost.MainWindow.ActiveDatabase.Modified = true;
-                }
-                catch (Exception)
-                {
-                }
+                _entry.CreateBackup(_plugin.PluginHost.MainWindow.ActiveDatabase);
+                _entry.Strings.Remove(_plugin.PluginHost.CustomConfig.GetString(KeeTrayTOTPExt.setname_string_TOTPSeed_StringName, Localization.Strings.TOTPSeed));
+                _entry.Strings.Remove(_plugin.PluginHost.CustomConfig.GetString(KeeTrayTOTPExt.setname_string_TOTPSettings_StringName, Localization.Strings.TOTPSettings));
+                _entry.Touch(true);
+                _plugin.PluginHost.MainWindow.ActiveDatabase.Modified = true;
+
                 DialogResult = DialogResult.OK;
                 Close();
             }

--- a/KeeTrayTOTP/SetupTOTP.cs
+++ b/KeeTrayTOTP/SetupTOTP.cs
@@ -212,14 +212,20 @@ namespace KeeTrayTOTP
         /// <param name="e"></param>
         private void ButtonDelete_Click(object sender, EventArgs e)
         {
+            //if (_plugin.SettingsCheck(entry) || _plugin.SeedCheck(entry))
             if (MessageBox.Show(Localization.Strings.SetupMessageAskDeleteCurrentEntry, Localization.Strings.TrayTOTPPlugin, MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.Yes)
             {
-                _entry.CreateBackup(_plugin.PluginHost.MainWindow.ActiveDatabase);
-                _entry.Strings.Remove(_plugin.PluginHost.CustomConfig.GetString(KeeTrayTOTPExt.setname_string_TOTPSeed_StringName, Localization.Strings.TOTPSeed));
-                _entry.Strings.Remove(_plugin.PluginHost.CustomConfig.GetString(KeeTrayTOTPExt.setname_string_TOTPSettings_StringName, Localization.Strings.TOTPSettings));
-                _entry.Touch(true);
-                _plugin.PluginHost.MainWindow.ActiveDatabase.Modified = true;
-
+                try
+                {
+                    _entry.CreateBackup(_plugin.PluginHost.MainWindow.ActiveDatabase);
+                    _entry.Strings.Remove(_plugin.PluginHost.CustomConfig.GetString(KeeTrayTOTPExt.setname_string_TOTPSeed_StringName, Localization.Strings.TOTPSeed));
+                    _entry.Strings.Remove(_plugin.PluginHost.CustomConfig.GetString(KeeTrayTOTPExt.setname_string_TOTPSettings_StringName, Localization.Strings.TOTPSettings));
+                    _entry.Touch(true);
+                    _plugin.PluginHost.MainWindow.ActiveDatabase.Modified = true;
+                }
+                catch (Exception)
+                {
+                }
                 DialogResult = DialogResult.OK;
                 Close();
             }

--- a/coverlet.runsettings
+++ b/coverlet.runsettings
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <Format>opencover</Format>          
+          <IncludeTestAssembly>true</IncludeTestAssembly>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
This is a work in progress:
* [x] ~SonarQube analysis currently fails on the code coverage.~ Code Coverage is working
* [x] SonarQube  defaults to at least 80 % code coverage. We are at 46%

Remarks:
  * SonarCloud bot currently comments on PR's and is not required, for merging, which is good, because it currently fails.
 * There are some badges as well that we could add to the readme