### PR TITLE
Default totp settings

### DIFF
--- a/KeeTrayTOTP.Tests/TOTPEntryValidatorTests.cs
+++ b/KeeTrayTOTP.Tests/TOTPEntryValidatorTests.cs
@@ -1,0 +1,61 @@
+﻿using FluentAssertions;
+using KeePassLib;
+using KeePassLib.Security;
+using KeeTrayTOTP.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace KeeTrayTOTP.Tests
+{
+    [TestClass]
+    public class TOTPEntryValidatorTests
+    {
+        private readonly Mock<ISettings> _settingsMock;
+        private readonly TOTPEntryValidator _sut;
+        private readonly PwEntry _entry;
+
+        public TOTPEntryValidatorTests()
+        {
+            this._settingsMock = new Mock<ISettings>(MockBehavior.Strict);
+            this._settingsMock.Setup(c => c.TOTPSettingsStringName).Returns("TOTP Settings");
+            this._settingsMock.Setup(c => c.TOTPSeedStringName).Returns("TOTP Seed");
+            this._sut = new TOTPEntryValidator(_settingsMock.Object);
+            this._entry = new PwEntry(true, false);
+        }
+
+        [TestMethod]
+        public void CanGenerateOtp_EntryHasNoSettingsOrSeed_ReturnsFalse()
+        {
+            _entry.Strings.Set(_settingsMock.Object.TOTPSeedStringName, new ProtectedString(false, "ABCDEFG"));
+            var act = _sut.CanGenerateTOTP(_entry);
+
+            act.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void CanGenerateOtp_EntryOnlyHasSeed_ReturnsTrue()
+        {
+            var act = _sut.CanGenerateTOTP(_entry);
+
+            act.Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void SettingsGet_EntryHasNoSettings_ReturnsDefaultSettings()
+        {
+            var act = _sut.SettingsGet(_entry);
+
+            act.Should().BeEquivalentTo("30", "6");
+        }
+
+        [TestMethod]
+        public void SettingsGet_EntryHasSettings_ShouldReturnOwnSettings()
+        {
+            _entry.Strings.Set(_settingsMock.Object.TOTPSettingsStringName, new ProtectedString(false, "60;7;https://pool.ntp.org"));
+
+            var act = _sut.SettingsGet(_entry);
+
+            act.Should().BeEquivalentTo("60", "7", "https://pool.ntp.org");
+        }
+    }
+}

--- a/KeeTrayTOTP.Tests/TrayTOTP_ColumnproviderTests.cs
+++ b/KeeTrayTOTP.Tests/TrayTOTP_ColumnproviderTests.cs
@@ -27,9 +27,9 @@ namespace KeeTrayTOTP.Tests
         [DataRow(ValidSeed, ValidSettings, "TOTP Enabled")]
         [DataRow(ValidSeed, ";6", "Error, bad settings!")]
         [DataRow(ValidSeed, "30", "Error, bad settings!")]
-        [DataRow(ValidSeed, null, "Error, storage!")]
+        [DataRow(ValidSeed, null, "TOTP Enabled")]
         [DataRow(InvalidSeed, ValidSettings, "Error, bad seed!")]
-        [DataRow(null, ValidSettings, "Error, storage!")]
+        [DataRow(null, ValidSettings, "Error, no seed!")]
         [DataRow(null, null, "")]
         [DataTestMethod]
         public void GetCellDataStatus_ShouldReturnExpectedValues(string seed, string settings, string expected)
@@ -52,9 +52,8 @@ namespace KeeTrayTOTP.Tests
 
         [DataRow(ValidSeed, ";6", "Error, bad settings!")]
         [DataRow(ValidSeed, "30", "Error, bad settings!")]
-        [DataRow(ValidSeed, null, "Error, storage!")]
         [DataRow(InvalidSeed, ValidSettings, "Error, bad seed!")]
-        [DataRow(null, ValidSettings, "Error, storage!")]
+        [DataRow(null, ValidSettings, "Error, no seed!")]
         [DataRow(null, null, "")]
         [DataTestMethod]
         public void GetCellDataCode_ShouldReturnExpectedValues(string seed, string settings, string expected)

--- a/KeeTrayTOTP/FormTimeCorrection.cs
+++ b/KeeTrayTOTP/FormTimeCorrection.cs
@@ -58,14 +58,11 @@ namespace KeeTrayTOTP
             {
                 foreach (var pe in _plugin.PluginHost.MainWindow.ActiveDatabase.RootGroup.GetEntries(true))
                 {
-                    if (_plugin.TOTPEntryValidator.SettingsCheck(pe))
+                    string[] settings = _plugin.TOTPEntryValidator.SettingsGet(pe);
+                    bool validUrl;
+                    if (_plugin.TOTPEntryValidator.SettingsValidate(pe, out validUrl) && validUrl && !ComboBoxUrlTimeCorrection.Items.Contains(settings[2]) && _plugin.TimeCorrections[settings[2]] == null)
                     {
-                        string[] settings = _plugin.TOTPEntryValidator.SettingsGet(pe);
-                        bool validUrl;
-                        if (_plugin.TOTPEntryValidator.SettingsValidate(pe, out validUrl) && validUrl && !ComboBoxUrlTimeCorrection.Items.Contains(settings[2]) && _plugin.TimeCorrections[settings[2]] == null)
-                        {
-                            ComboBoxUrlTimeCorrection.Items.Add(settings[2]);
-                        }
+                        ComboBoxUrlTimeCorrection.Items.Add(settings[2]);
                     }
                 }
             }

--- a/KeeTrayTOTP/FormTimeCorrection.cs
+++ b/KeeTrayTOTP/FormTimeCorrection.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Linq;
 using System.Windows.Forms;
 using KeePass.UI;
+using KeeTrayTOTP.Helpers;
 using KeeTrayTOTP.Libraries;
 
 namespace KeeTrayTOTP
@@ -56,11 +58,11 @@ namespace KeeTrayTOTP
             {
                 foreach (var pe in _plugin.PluginHost.MainWindow.ActiveDatabase.RootGroup.GetEntries(true))
                 {
-                    if (_plugin.SettingsCheck(pe))
+                    if (_plugin.TOTPEntryValidator.SettingsCheck(pe))
                     {
-                        string[] settings = _plugin.SettingsGet(pe);
+                        string[] settings = _plugin.TOTPEntryValidator.SettingsGet(pe);
                         bool validUrl;
-                        if (_plugin.SettingsValidate(pe, out validUrl) && validUrl && !ComboBoxUrlTimeCorrection.Items.Contains(settings[2]) && _plugin.TimeCorrections[settings[2]] == null)
+                        if (_plugin.TOTPEntryValidator.SettingsValidate(pe, out validUrl) && validUrl && !ComboBoxUrlTimeCorrection.Items.Contains(settings[2]) && _plugin.TimeCorrections[settings[2]] == null)
                         {
                             ComboBoxUrlTimeCorrection.Items.Add(settings[2]);
                         }

--- a/KeeTrayTOTP/Helpers/TOTPEntryValidator.cs
+++ b/KeeTrayTOTP/Helpers/TOTPEntryValidator.cs
@@ -1,0 +1,183 @@
+﻿using KeePassLib;
+using KeePassLib.Security;
+using KeeTrayTOTP.Libraries;
+using System;
+using System.Collections.ObjectModel;
+
+namespace KeeTrayTOTP.Helpers
+{
+    // TODO: stil not the right name: Also gets settings?
+    public class TOTPEntryValidator
+    {
+        private static readonly ReadOnlyCollection<string> AllowedLengths = new ReadOnlyCollection<string>(new[] { "6", "7", "8", "S" });
+        private readonly ISettings _settings;
+
+        public TOTPEntryValidator(ISettings settings)
+        {
+            this._settings = settings;
+        }
+
+        /// <summary>
+        /// Check if specified Entry contains Settings that are not null.
+        /// </summary>
+        /// <returns>Presence of Settings.</returns>
+        internal bool SettingsCheck(PwEntry entry)
+        {
+            return entry.Strings.Exists(_settings.TOTPSettingsStringName);
+        }
+
+        /// <summary>
+        /// Check if specified Entry's Interval and Length are valid.
+        /// </summary>
+        /// <returns>Error(s) while validating Interval or Length.</returns>
+        internal bool SettingsValidate(PwEntry entry)
+        {
+            bool validInterval;
+            bool validLength;
+            bool validUrl;
+
+            return SettingsValidate(entry, out validInterval, out validLength, out validUrl);
+        }
+
+        /// <summary>
+        /// Check if specified Entry's Interval and Length are valid. The URL status is available as an out boolean.
+        /// </summary>
+        /// <param name="isUrlValid">Url Validity.</param>
+        /// <returns>Error(s) while validating Interval or Length.</returns>
+        internal bool SettingsValidate(PwEntry entry, out bool isUrlValid)
+        {
+            bool validInterval; bool validLength; //Dummies
+
+            return SettingsValidate(entry, out validInterval, out validLength, out isUrlValid);
+        }
+
+        /// <summary>
+        /// Check if specified Entry's Interval and Length are valid. All settings statuses are available as out booleans.
+        /// </summary>
+        /// <param name="isIntervalValid">Interval Validity.</param>
+        /// <param name="isLengthValid">Length Validity.</param>
+        /// <param name="isUrlValid">Url Validity.</param>
+        /// <returns>Error(s) while validating Interval or Length.</returns>
+        internal bool SettingsValidate(PwEntry entry, out bool isIntervalValid, out bool isLengthValid, out bool isUrlValid)
+        {
+            bool settingsValid;
+            try
+            {
+                string[] settings = SettingsGet(entry);
+
+                isIntervalValid = IntervalIsValid(settings);
+                isLengthValid = LengthIsValid(settings);
+
+                settingsValid = isIntervalValid && isLengthValid;
+
+                isUrlValid = UrlIsValid(settings);
+            }
+            catch (Exception)
+            {
+                isIntervalValid = false;
+                isLengthValid = false;
+                isUrlValid = false;
+                settingsValid = false;
+            }
+            return settingsValid;
+        }
+
+        private static bool UrlIsValid(string[] settings)
+        {
+            if (settings.Length < 3)
+            {
+                return false;
+            }
+
+            return settings[2].StartsWith("http://") || settings[2].StartsWith("https://");
+        }
+
+        private static bool LengthIsValid(string[] settings)
+        {
+            if (settings.Length < 2)
+            {
+                return false;
+            }
+
+            if (!AllowedLengths.Contains(settings[1]))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private static bool IntervalIsValid(string[] settings)
+        {
+            if (settings.Length == 0)
+            {
+                return false;
+            }
+
+            short interval;
+            if (!short.TryParse(settings[0], out interval))
+            {
+                return false;
+            }
+
+            if (interval < 0 && interval < 180)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Get the entry's Settings using the string name specified in the settings (or default).
+        /// </summary>
+        /// <param name="pe">Password Entry.</param>
+        /// <returns>String Array (Interval, Length, Url).</returns>
+        internal string[] SettingsGet(PwEntry entry)
+        {
+            return entry.Strings.Get(_settings.TOTPSettingsStringName).ReadString().Split(';');
+        }
+
+        /// <summary>
+        /// Check if the specified Entry contains a Seed.
+        /// </summary>
+        /// <returns>Presence of the Seed.</returns>
+        internal bool SeedCheck(PwEntry entry)
+        {
+            return entry.Strings.Exists(_settings.TOTPSeedStringName);
+        }
+
+        /// <summary>
+        /// Validates the entry's Seed making sure it's a valid Base32 string.
+        /// </summary>
+        /// <returns>Validity of the Seed's characters for Base32 format.</returns>
+        internal bool SeedValidate(PwEntry entry)
+        {
+            return SeedGet(entry).ReadString().ExtWithoutSpaces().IsBase32();
+        }
+
+        /// <summary>
+        /// Validates the entry's Seed making sure it's a valid Base32 string. Invalid characters are available as out string.
+        /// </summary>
+        /// <param name="invalidCharacters">Password Entry.</param>
+        /// <returns>Validity of the Seed's characters.</returns>
+        internal bool SeedValidate(PwEntry entry, out string invalidCharacters)
+        {
+            return SeedGet(entry).ReadString().ExtWithoutSpaces().IsBase32(out invalidCharacters);
+        }
+
+        /// <summary>
+        /// Get the entry's Seed using the string name specified in the settings (or default).
+        /// </summary>
+        /// <returns>Protected Seed.</returns>
+        internal ProtectedString SeedGet(PwEntry entry)
+        {
+            return entry.Strings.Get(_settings.TOTPSeedStringName);
+        }
+
+        internal bool CanGenerateTOTP(PwEntry entry)
+        {
+            return SettingsCheck(entry) && SeedCheck(entry) && SettingsValidate(entry) && SeedValidate(entry);
+        }
+    }
+}

--- a/KeeTrayTOTP/Helpers/TOTPEntryValidator.cs
+++ b/KeeTrayTOTP/Helpers/TOTPEntryValidator.cs
@@ -18,15 +18,6 @@ namespace KeeTrayTOTP.Helpers
         }
 
         /// <summary>
-        /// Check if specified Entry contains Settings that are not null.
-        /// </summary>
-        /// <returns>Presence of Settings.</returns>
-        internal bool SettingsCheck(PwEntry entry)
-        {
-            return entry.Strings.Exists(_settings.TOTPSettingsStringName);
-        }
-
-        /// <summary>
         /// Check if specified Entry's Interval and Length are valid.
         /// </summary>
         /// <returns>Error(s) while validating Interval or Length.</returns>
@@ -82,6 +73,68 @@ namespace KeeTrayTOTP.Helpers
             return settingsValid;
         }
 
+        /// <summary>
+        /// Get the entry's Settings, or return defaults
+        /// </summary>
+        /// <returns>String Array (Interval, Length, Url).</returns>
+        internal string[] SettingsGet(PwEntry entry)
+        {
+            return HasExplicitSettings(entry)
+                ? entry.Strings.Get(_settings.TOTPSettingsStringName).ReadString().Split(';')
+                : new[] { "30", "6" };
+        }
+
+        /// <summary>
+        /// Check if the specified Entry contains a Seed.
+        /// </summary>
+        /// <returns>Presence of the Seed.</returns>
+        internal bool HasSeed(PwEntry entry)
+        {
+            return entry.Strings.Exists(_settings.TOTPSeedStringName);
+        }
+
+        /// <summary>
+        /// Validates the entry's Seed making sure it's a valid Base32 string.
+        /// </summary>
+        /// <returns>Validity of the Seed's characters for Base32 format.</returns>
+        internal bool SeedValidate(PwEntry entry)
+        {
+            return SeedGet(entry).ReadString().ExtWithoutSpaces().IsBase32();
+        }
+
+        /// <summary>
+        /// Validates the entry's Seed making sure it's a valid Base32 string. Invalid characters are available as out string.
+        /// </summary>
+        /// <param name="invalidCharacters">Password Entry.</param>
+        /// <returns>Validity of the Seed's characters.</returns>
+        internal bool SeedValidate(PwEntry entry, out string invalidCharacters)
+        {
+            return SeedGet(entry).ReadString().ExtWithoutSpaces().IsBase32(out invalidCharacters);
+        }
+
+        /// <summary>
+        /// Get the entry's Seed using the string name specified in the settings (or default).
+        /// </summary>
+        /// <returns>Protected Seed.</returns>
+        internal ProtectedString SeedGet(PwEntry entry)
+        {
+            return entry.Strings.Get(_settings.TOTPSeedStringName);
+        }
+
+        internal bool CanGenerateTOTP(PwEntry entry)
+        {
+            return HasSeed(entry) && SettingsValidate(entry) && SeedValidate(entry);
+        }
+
+        /// <summary>
+        /// Check if specified Entry contains Settings that are not null.
+        /// </summary>
+        /// <returns>Presence of Settings.</returns>
+        internal bool HasExplicitSettings(PwEntry entry)
+        {
+            return entry.Strings.Exists(_settings.TOTPSettingsStringName);
+        }
+
         private static bool UrlIsValid(string[] settings)
         {
             if (settings.Length < 3)
@@ -120,7 +173,7 @@ namespace KeeTrayTOTP.Helpers
                 return false;
             }
 
-            if (interval < 0 && interval < 180)
+            if (interval < 0)
             {
                 return false;
             }
@@ -128,56 +181,5 @@ namespace KeeTrayTOTP.Helpers
             return true;
         }
 
-        /// <summary>
-        /// Get the entry's Settings using the string name specified in the settings (or default).
-        /// </summary>
-        /// <param name="pe">Password Entry.</param>
-        /// <returns>String Array (Interval, Length, Url).</returns>
-        internal string[] SettingsGet(PwEntry entry)
-        {
-            return entry.Strings.Get(_settings.TOTPSettingsStringName).ReadString().Split(';');
-        }
-
-        /// <summary>
-        /// Check if the specified Entry contains a Seed.
-        /// </summary>
-        /// <returns>Presence of the Seed.</returns>
-        internal bool SeedCheck(PwEntry entry)
-        {
-            return entry.Strings.Exists(_settings.TOTPSeedStringName);
-        }
-
-        /// <summary>
-        /// Validates the entry's Seed making sure it's a valid Base32 string.
-        /// </summary>
-        /// <returns>Validity of the Seed's characters for Base32 format.</returns>
-        internal bool SeedValidate(PwEntry entry)
-        {
-            return SeedGet(entry).ReadString().ExtWithoutSpaces().IsBase32();
-        }
-
-        /// <summary>
-        /// Validates the entry's Seed making sure it's a valid Base32 string. Invalid characters are available as out string.
-        /// </summary>
-        /// <param name="invalidCharacters">Password Entry.</param>
-        /// <returns>Validity of the Seed's characters.</returns>
-        internal bool SeedValidate(PwEntry entry, out string invalidCharacters)
-        {
-            return SeedGet(entry).ReadString().ExtWithoutSpaces().IsBase32(out invalidCharacters);
-        }
-
-        /// <summary>
-        /// Get the entry's Seed using the string name specified in the settings (or default).
-        /// </summary>
-        /// <returns>Protected Seed.</returns>
-        internal ProtectedString SeedGet(PwEntry entry)
-        {
-            return entry.Strings.Get(_settings.TOTPSeedStringName);
-        }
-
-        internal bool CanGenerateTOTP(PwEntry entry)
-        {
-            return SettingsCheck(entry) && SeedCheck(entry) && SettingsValidate(entry) && SeedValidate(entry);
-        }
     }
 }

--- a/KeeTrayTOTP/ISettings.cs
+++ b/KeeTrayTOTP/ISettings.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace KeeTrayTOTP
 {
@@ -8,7 +9,9 @@ namespace KeeTrayTOTP
         string AutoTypeFieldName { get; set; }
         bool EntryContextCopyVisible { get; set; }
         bool EntryContextSetupVisible { get; set; }
+        int EntryListRefreshRate { get; }
         bool FirstInstallShown { get; set; }
+        bool LegacyTrayMenuProviderEnable { get; set; }
         bool NotifyContextVisible { get; set; }
         bool TimeCorrectionEnable { get; set; }
         IEnumerable<string> TimeCorrectionList { get; set; }
@@ -17,6 +20,7 @@ namespace KeeTrayTOTP
         bool TOTPColumnTimerVisible { get; set; }
         string TOTPSeedStringName { get; set; }
         string TOTPSettingsStringName { get; set; }
+        int TrimTextLength { get; }
         bool TrimTrayText { get; set; }
     }
 }

--- a/KeeTrayTOTP/KeeTrayTOTP.csproj
+++ b/KeeTrayTOTP/KeeTrayTOTP.csproj
@@ -76,11 +76,12 @@
     <Compile Include="Helpers\DocumentExtensions.cs" />
     <Compile Include="Helpers\MenuItemHelper.cs" />
     <Compile Include="Helpers\ImageExtensions.cs" />
+    <Compile Include="Helpers\TOTPEntryValidator.cs" />
+    <Compile Include="ISettings.cs" />
     <Compile Include="Menu\EntryMenuItemProvider.cs" />
     <Compile Include="Menu\MainMenuItemProvider.cs" />
     <Compile Include="Menu\MenuItemProvider.cs" />
     <Compile Include="Menu\LegacyTrayMenuItemProvider.cs" />
-    <Compile Include="ISettings.cs" />
     <Compile Include="Libraries\DropDownLocationCalculator.cs" />
     <Compile Include="FormAbout.cs">
       <SubType>Form</SubType>

--- a/KeeTrayTOTP/Localization/Strings.Designer.cs
+++ b/KeeTrayTOTP/Localization/Strings.Designer.cs
@@ -124,15 +124,6 @@ namespace KeeTrayTOTP.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Error.
-        /// </summary>
-        internal static string Error {
-            get {
-                return ResourceManager.GetString("Error", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Error, bad seed!.
         /// </summary>
         internal static string ErrorBadSeed {
@@ -151,20 +142,11 @@ namespace KeeTrayTOTP.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Error, no settings!.
+        ///   Looks up a localized string similar to Error, no seed!.
         /// </summary>
-        internal static string ErrorNoSettings {
+        internal static string ErrorNoSeed {
             get {
-                return ResourceManager.GetString("ErrorNoSettings", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Error, storage!.
-        /// </summary>
-        internal static string ErrorStorage {
-            get {
-                return ResourceManager.GetString("ErrorStorage", resourceCulture);
+                return ResourceManager.GetString("ErrorNoSeed", resourceCulture);
             }
         }
         
@@ -394,33 +376,6 @@ namespace KeeTrayTOTP.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Next step..
-        /// </summary>
-        internal static string SetupNext {
-            get {
-                return ResourceManager.GetString("SetupNext", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Previous step..
-        /// </summary>
-        internal static string SetupPrevious {
-            get {
-                return ResourceManager.GetString("SetupPrevious", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Create or applies changes to the current entry&apos;s TOTP Settings..
-        /// </summary>
-        internal static string SetupProceed {
-            get {
-                return ResourceManager.GetString("SetupProceed", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Seed cannot be empty!.
         /// </summary>
         internal static string SetupSeedCantBeEmpty {
@@ -435,15 +390,6 @@ namespace KeeTrayTOTP.Localization {
         internal static string SetupTOTP {
             get {
                 return ResourceManager.GetString("SetupTOTP", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to URL must include &quot;http&quot;!.
-        /// </summary>
-        internal static string SetupUrlMustContainHttp {
-            get {
-                return ResourceManager.GetString("SetupUrlMustContainHttp", resourceCulture);
             }
         }
         

--- a/KeeTrayTOTP/Localization/Strings.resx
+++ b/KeeTrayTOTP/Localization/Strings.resx
@@ -138,21 +138,14 @@
   <data name="DatabaseIsNotOpen" xml:space="preserve">
     <value>Database is not open!</value>
   </data>
-  <data name="Error" xml:space="preserve">
-    <value>Error</value>
-    <comment>Just the word "error"</comment>
-  </data>
   <data name="ErrorBadSeed" xml:space="preserve">
     <value>Error, bad seed!</value>
   </data>
   <data name="ErrorBadSettings" xml:space="preserve">
     <value>Error, bad settings!</value>
   </data>
-  <data name="ErrorNoSettings" xml:space="preserve">
-    <value>Error, no settings!</value>
-  </data>
-  <data name="ErrorStorage" xml:space="preserve">
-    <value>Error, storage!</value>
+  <data name="ErrorNoSeed" xml:space="preserve">
+    <value>Error, no seed!</value>
   </data>
   <data name="Help" xml:space="preserve">
     <value>Help</value>
@@ -231,23 +224,11 @@
   <data name="SetupMessageAskDeleteCurrentEntry" xml:space="preserve">
     <value>Are you sure you want to delete the current entry's TOTP settings?</value>
   </data>
-  <data name="SetupNext" xml:space="preserve">
-    <value>Next step.</value>
-  </data>
-  <data name="SetupPrevious" xml:space="preserve">
-    <value>Previous step.</value>
-  </data>
-  <data name="SetupProceed" xml:space="preserve">
-    <value>Create or applies changes to the current entry's TOTP Settings.</value>
-  </data>
   <data name="SetupSeedCantBeEmpty" xml:space="preserve">
     <value>Seed cannot be empty!</value>
   </data>
   <data name="SetupTOTP" xml:space="preserve">
     <value>Setup TOTP</value>
-  </data>
-  <data name="SetupUrlMustContainHttp" xml:space="preserve">
-    <value>URL must include "http"!</value>
   </data>
   <data name="ShowQR" xml:space="preserve">
     <value>Show QR</value>

--- a/KeeTrayTOTP/Menu/EntryMenuItemProvider.cs
+++ b/KeeTrayTOTP/Menu/EntryMenuItemProvider.cs
@@ -4,6 +4,7 @@ using System.Windows.Forms;
 using KeePass.Plugins;
 using KeePass.UI;
 using KeePassLib;
+using KeeTrayTOTP.Helpers;
 
 namespace KeeTrayTOTP.Menu
 {
@@ -41,8 +42,8 @@ namespace KeeTrayTOTP.Menu
                 if (_pluginHost.MainWindow.GetSelectedEntriesCount() == 1)
                 {
                     var currentEntry = _pluginHost.MainWindow.GetSelectedEntry(true);
-                    if (_plugin.SettingsCheck(currentEntry) && _plugin.SeedCheck(currentEntry) &&
-                        _plugin.SettingsValidate(currentEntry))
+                    if (_plugin.TOTPEntryValidator.SettingsCheck(currentEntry) && _plugin.TOTPEntryValidator.SeedCheck(currentEntry) &&
+                        _plugin.TOTPEntryValidator.SettingsValidate(currentEntry))
                     {
                         entryMenuCopyTotp.Enabled = true;
                         entryMenuShowQrCode.Enabled = true;
@@ -75,12 +76,12 @@ namespace KeeTrayTOTP.Menu
 
             var entry = _pluginHost.MainWindow.GetSelectedEntry(true);
 
-            if (!_plugin.SeedCheck(entry))
+            if (!_plugin.TOTPEntryValidator.SeedCheck(entry))
             {
                 return;
             }
 
-            var rawSeed = _plugin.SeedGet(entry).ReadString();
+            var rawSeed = _plugin.TOTPEntryValidator.SeedGet(entry).ReadString();
             var cleanSeed = Regex.Replace(rawSeed, @"\s+", "").TrimEnd('=');
             var issuer = entry.Strings.Get("Title").ReadString();
             var username = entry.Strings.Get("UserName").ReadString();

--- a/KeeTrayTOTP/Menu/EntryMenuItemProvider.cs
+++ b/KeeTrayTOTP/Menu/EntryMenuItemProvider.cs
@@ -42,7 +42,7 @@ namespace KeeTrayTOTP.Menu
                 if (_pluginHost.MainWindow.GetSelectedEntriesCount() == 1)
                 {
                     var currentEntry = _pluginHost.MainWindow.GetSelectedEntry(true);
-                    if (_plugin.TOTPEntryValidator.SettingsCheck(currentEntry) && _plugin.TOTPEntryValidator.SeedCheck(currentEntry) &&
+                    if (_plugin.TOTPEntryValidator.HasSeed(currentEntry) &&
                         _plugin.TOTPEntryValidator.SettingsValidate(currentEntry))
                     {
                         entryMenuCopyTotp.Enabled = true;
@@ -76,7 +76,7 @@ namespace KeeTrayTOTP.Menu
 
             var entry = _pluginHost.MainWindow.GetSelectedEntry(true);
 
-            if (!_plugin.TOTPEntryValidator.SeedCheck(entry))
+            if (!_plugin.TOTPEntryValidator.HasSeed(entry))
             {
                 return;
             }

--- a/KeeTrayTOTP/Menu/TrayMenuItemProvider.cs
+++ b/KeeTrayTOTP/Menu/TrayMenuItemProvider.cs
@@ -208,7 +208,7 @@ namespace KeeTrayTOTP.Menu
 
             var menuItem = new ToolStripMenuItem(trayTitle, Resources.TOTP_Key, OnNotifyMenuTOTPClick);
             menuItem.Tag = entry;
-            if (!Plugin.SettingsValidate(entry))
+            if (!Plugin.TOTPEntryValidator.SettingsValidate(entry))
             {
                 menuItem.Enabled = false;
                 menuItem.Image = Resources.TOTP_Error;

--- a/KeeTrayTOTP/Settings.cs
+++ b/KeeTrayTOTP/Settings.cs
@@ -45,7 +45,6 @@ namespace KeeTrayTOTP
             internal const int TimeCorrectionRefreshTime = 60;
             internal const int TrimTextLength = 25;
             internal const int EntryListRefreshRate = 300;
-            internal static readonly ReadOnlyCollection<string> AllowedLengths = new ReadOnlyCollection<string>(new[] { "6", "7", "8", "S" });
         }
 
         private readonly AceCustomConfig _keePassCustomConfig;
@@ -53,11 +52,6 @@ namespace KeeTrayTOTP
         public Settings(AceCustomConfig keepassCustomConfig)
         {
             this._keePassCustomConfig = keepassCustomConfig;
-        }
-
-        public ReadOnlyCollection<string> AllowedLengths
-        {
-            get { return SettingDefaults.AllowedLengths; }
         }
 
         public int TrimTextLength

--- a/KeeTrayTOTP/SetupTOTP.cs
+++ b/KeeTrayTOTP/SetupTOTP.cs
@@ -3,6 +3,7 @@ using System.Windows.Forms;
 using KeePass.UI;
 using KeePassLib;
 using KeePassLib.Security;
+using KeeTrayTOTP.Helpers;
 using KeeTrayTOTP.Libraries;
 
 namespace KeeTrayTOTP
@@ -36,13 +37,13 @@ namespace KeeTrayTOTP
 
             Text = Localization.Strings.Setup + " - " + Localization.Strings.TrayTOTPPlugin; //Set form's name using constants.
 
-            if (_plugin.SettingsCheck(_entry) || _plugin.SeedCheck(_entry)) //Checks the the totp settings exists.
+            if (_plugin.TOTPEntryValidator.SettingsCheck(_entry) || _plugin.TOTPEntryValidator.SeedCheck(_entry)) //Checks the the totp settings exists.
             {
-                string[] settings = _plugin.SettingsGet(_entry); //Gets the the existing totp settings.
+                string[] settings = _plugin.TOTPEntryValidator.SettingsGet(_entry); //Gets the the existing totp settings.
                 bool validInterval;
                 bool validLength;
                 bool validUrl;
-                _plugin.SettingsValidate(_entry, out validInterval, out validLength, out validUrl); //Validates the settings value.
+                _plugin.TOTPEntryValidator.SettingsValidate(_entry, out validInterval, out validLength, out validUrl); //Validates the settings value.
                 if (validInterval)
                 {
                     NumericIntervalSetup.Value = Convert.ToDecimal(settings[0]); //Checks if interval is valid and sets interval numeric to the setting value.
@@ -69,9 +70,9 @@ namespace KeeTrayTOTP
                 DeleteSetupButton.Visible = false; //Hides the back button.
             }
 
-            if (_plugin.SeedCheck(_entry))
+            if (_plugin.TOTPEntryValidator.SeedCheck(_entry))
             {
-                TextBoxSeedSetup.Text = _plugin.SeedGet(_entry).ReadString(); //Checks if the seed exists and sets seed textbox to the seed value.
+                TextBoxSeedSetup.Text = _plugin.TOTPEntryValidator.SeedGet(_entry).ReadString(); //Checks if the seed exists and sets seed textbox to the seed value.
             }
 
             ComboBoxTimeCorrectionSetup.Items.AddRange(_plugin.TimeCorrections.ToComboBox()); //Gets existings time corrections and adds them in the combobox.

--- a/KeeTrayTOTP/SetupTOTP.cs
+++ b/KeeTrayTOTP/SetupTOTP.cs
@@ -37,7 +37,7 @@ namespace KeeTrayTOTP
 
             Text = Localization.Strings.Setup + " - " + Localization.Strings.TrayTOTPPlugin; //Set form's name using constants.
 
-            if (_plugin.TOTPEntryValidator.SettingsCheck(_entry) || _plugin.TOTPEntryValidator.SeedCheck(_entry)) //Checks the the totp settings exists.
+            if (_plugin.TOTPEntryValidator.HasSeed(_entry)) //Checks the the totp settings exists.
             {
                 string[] settings = _plugin.TOTPEntryValidator.SettingsGet(_entry); //Gets the the existing totp settings.
                 bool validInterval;
@@ -70,7 +70,7 @@ namespace KeeTrayTOTP
                 DeleteSetupButton.Visible = false; //Hides the back button.
             }
 
-            if (_plugin.TOTPEntryValidator.SeedCheck(_entry))
+            if (_plugin.TOTPEntryValidator.HasSeed(_entry))
             {
                 TextBoxSeedSetup.Text = _plugin.TOTPEntryValidator.SeedGet(_entry).ReadString(); //Checks if the seed exists and sets seed textbox to the seed value.
             }

--- a/KeeTrayTOTP/TrayTOTP_ColumnProvider.cs
+++ b/KeeTrayTOTP/TrayTOTP_ColumnProvider.cs
@@ -53,10 +53,7 @@ namespace KeeTrayTOTP
 
         private string GetCellDataInternal(PwEntry pe, Func<PwEntry, string> innerValueFunc)
         {
-            var settingsCheck = _plugin.TOTPEntryValidator.SettingsCheck(pe);
-            var seedCheck = _plugin.TOTPEntryValidator.SeedCheck(pe);
-
-            if (settingsCheck && seedCheck)
+            if (_plugin.TOTPEntryValidator.HasSeed(pe))
             {
                 if (_plugin.TOTPEntryValidator.SettingsValidate(pe))
                 {
@@ -68,7 +65,7 @@ namespace KeeTrayTOTP
                 }
                 return Localization.Strings.ErrorBadSettings;
             }
-            return (settingsCheck || seedCheck) ? Localization.Strings.ErrorStorage : string.Empty;
+            return _plugin.TOTPEntryValidator.HasExplicitSettings(pe) ? Localization.Strings.ErrorNoSeed : string.Empty;
         }
 
         private static string GetInnerValueStatus(PwEntry entry)

--- a/KeeTrayTOTP/TrayTOTP_ColumnProvider.cs
+++ b/KeeTrayTOTP/TrayTOTP_ColumnProvider.cs
@@ -53,14 +53,14 @@ namespace KeeTrayTOTP
 
         private string GetCellDataInternal(PwEntry pe, Func<PwEntry, string> innerValueFunc)
         {
-            var settingsCheck = _plugin.SettingsCheck(pe);
-            var seedCheck = _plugin.SeedCheck(pe);
+            var settingsCheck = _plugin.TOTPEntryValidator.SettingsCheck(pe);
+            var seedCheck = _plugin.TOTPEntryValidator.SeedCheck(pe);
 
             if (settingsCheck && seedCheck)
             {
-                if (_plugin.SettingsValidate(pe))
+                if (_plugin.TOTPEntryValidator.SettingsValidate(pe))
                 {
-                    if (_plugin.SeedValidate(pe))
+                    if (_plugin.TOTPEntryValidator.SeedValidate(pe))
                     {
                         return innerValueFunc(pe);
                     }
@@ -78,9 +78,9 @@ namespace KeeTrayTOTP
 
         private string GetInnerValueCode(PwEntry entry)
         {
-            string[] settings = _plugin.SettingsGet(entry);
+            string[] settings = _plugin.TOTPEntryValidator.SettingsGet(entry);
             var totpGenerator = new TOTPProvider(settings, _plugin.TimeCorrections);
-            return totpGenerator.GenerateByByte(Base32.Decode(_plugin.SeedGet(entry).ReadString().ExtWithoutSpaces())) + (_plugin.Settings.TOTPColumnTimerVisible ? totpGenerator.Timer.ToString().ExtWithParenthesis().ExtWithSpaceBefore() : string.Empty);
+            return totpGenerator.GenerateByByte(Base32.Decode(_plugin.TOTPEntryValidator.SeedGet(entry).ReadString().ExtWithoutSpaces())) + (_plugin.Settings.TOTPColumnTimerVisible ? totpGenerator.Timer.ToString().ExtWithParenthesis().ExtWithSpaceBefore() : string.Empty);
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace KeeTrayTOTP
         /// <param name="pe">Entry associated with the clicked cell.</param>
         public override void PerformCellAction(string columnName, PwEntry pe)
         {
-            if (!_plugin.CanGenerateTOTP(pe))
+            if (!_plugin.TOTPEntryValidator.CanGenerateTOTP(pe))
             {
                 UIUtil.ShowDialogAndDestroy(new SetupTOTP(_plugin, pe));
             }

--- a/KeeTrayTOTP/TrayTOTP_Plugin.cs
+++ b/KeeTrayTOTP/TrayTOTP_Plugin.cs
@@ -211,9 +211,7 @@ namespace KeeTrayTOTP
         {
             var entries = pwGroup.GetEntries(true);
 
-            return entries
-                .Where(entry => !entry.IsExpired())
-                .Where(entry => TOTPEntryValidator.SettingsCheck(entry) && TOTPEntryValidator.SeedCheck(entry));
+            return entries.Where(entry => !entry.IsExpired() && TOTPEntryValidator.HasSeed(entry));
         }
 
         /// <summary>
@@ -247,7 +245,7 @@ namespace KeeTrayTOTP
                         _liGroupsPreviousSelected = selectedGroup;
                         foreach (var entry in selectedGroup.GetEntries(true))
                         {
-                            if (TOTPEntryValidator.SettingsCheck(entry) && TOTPEntryValidator.SeedCheck(entry))
+                            if (TOTPEntryValidator.HasSeed(entry))
                             {
                                 _liColumnTotpContains = true;
                             }
@@ -276,7 +274,7 @@ namespace KeeTrayTOTP
         {
             if ((e.Context.Flags & SprCompileFlags.ExtActive) == SprCompileFlags.ExtActive && e.Text.IndexOf(Settings.AutoTypeFieldName.ExtWithBrackets(), StringComparison.InvariantCultureIgnoreCase) >= 0)
             {
-                if (TOTPEntryValidator.SettingsCheck(e.Context.Entry) && TOTPEntryValidator.SeedCheck(e.Context.Entry))
+                if (TOTPEntryValidator.HasSeed(e.Context.Entry))
                 {
                     if (TOTPEntryValidator.SettingsValidate(e.Context.Entry))
                     {
@@ -311,7 +309,7 @@ namespace KeeTrayTOTP
                 else
                 {
                     e.Text = string.Empty;
-                    MessageService.ShowWarning(Localization.Strings.ErrorBadSettings);
+                    MessageService.ShowWarning(Localization.Strings.ErrorNoSeed);
                 }
             }
         }
@@ -322,7 +320,7 @@ namespace KeeTrayTOTP
         /// <param name="pe">Password Entry.</param>
         internal void TOTPCopyToClipboard(PwEntry pe)
         {
-            if (TOTPEntryValidator.SettingsCheck(pe) && TOTPEntryValidator.SeedCheck(pe))
+            if (TOTPEntryValidator.HasSeed(pe))
             {
                 if (TOTPEntryValidator.SettingsValidate(pe))
                 {
@@ -331,7 +329,7 @@ namespace KeeTrayTOTP
                     TOTPProvider totpGenerator = new TOTPProvider(settings, this.TimeCorrections);
 
                     string invalidCharacters;
-                    if (TOTPEntryValidator.SeedValidate(pe,out invalidCharacters))
+                    if (TOTPEntryValidator.SeedValidate(pe, out invalidCharacters))
                     {
                         pe.Touch(false);
 
@@ -356,7 +354,7 @@ namespace KeeTrayTOTP
             }
             else
             {
-                MessageService.ShowWarning(Localization.Strings.ErrorBadSettings);
+                MessageService.ShowWarning(Localization.Strings.ErrorNoSeed);
             }
         }
 


### PR DESCRIPTION
As suggested in #147 fall back to default settings (duration 30, length 6) when there are no explicit settings.

Separated getting settings to it's own class. Not fully sure on how to name it. For now called it `TOTPEntryValidator`, but that's not the only thing it does. This will also make it easier to switch to the KeyUri format.