### PR TITLE
Fixed missing shortcut keys on mono

### DIFF
--- a/KeeTrayTOTP.Tests/Menu/EntryMenuItemProviderTests.cs
+++ b/KeeTrayTOTP.Tests/Menu/EntryMenuItemProviderTests.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using FluentAssertions;
+using KeePass.UI;
+using KeePass.Util;
+using KeeTrayTOTP.Menu;
+using KeeTrayTOTP.Tests.Extensions;
+using KeeTrayTOTP.Tests.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace KeeTrayTOTP.Tests.Menu
+{
+    [TestClass]
+    public class EntryMenuItemProviderTests
+    {
+        private EntryMenuItemProvider _entryMenuItemProvider;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            var (plugin, host) = PluginHostHelper.CreateAndInitialize();
+
+            _entryMenuItemProvider = new EntryMenuItemProvider(plugin, host.Object);
+        }
+
+        [TestMethod]
+        public void EntryMenuItemProvider_Should_ProvideAllMenuItemsWithCorrectShortcutKeys()
+        {
+            var sut = _entryMenuItemProvider.ProvideMenuItem();
+
+            sut.DropDownItems.Count.Should().Be(3,
+                "because, there are exactly three menu items for an entry.");
+
+            sut.DropDownItems
+                .Cast<ToolStripMenuItem>()
+                .All(x => x.ShortcutKeys != Keys.None)
+                .Should().BeTrue("because, all entries should have a shortcut key assigned.");
+        }
+    }
+}

--- a/KeeTrayTOTP.Tests/Menu/EntryMenuItemProviderTests.cs
+++ b/KeeTrayTOTP.Tests/Menu/EntryMenuItemProviderTests.cs
@@ -37,7 +37,7 @@ namespace KeeTrayTOTP.Tests.Menu
 
             sut.DropDownItems
                 .Cast<ToolStripMenuItem>()
-                .All(x => x.ShortcutKeys != Keys.None)
+                .All(menuItem => menuItem.ShortcutKeys != Keys.None)
                 .Should().BeTrue("because, all entries should have a shortcut key assigned.");
         }
     }

--- a/KeeTrayTOTP/Menu/EntryMenuItemProvider.cs
+++ b/KeeTrayTOTP/Menu/EntryMenuItemProvider.cs
@@ -23,14 +23,23 @@ namespace KeeTrayTOTP.Menu
         {
             var rootEntryMenuItem = new ToolStripMenuItem(Localization.Strings.TrayTOTPPlugin, Properties.Resources.TOTP);
 
-            var entryMenuCopyTotp = new ToolStripMenuItem(Localization.Strings.CopyTOTP, Properties.Resources.TOTP, OnEntryMenuTOTPClick);
-            var entryMenuSetupTotp = new ToolStripMenuItem(Localization.Strings.SetupTOTP, Properties.Resources.TOTP_Setup, OnEntryMenuSetupClick);
-            var entryMenuShowQrCode = new ToolStripMenuItem(Localization.Strings.ShowQR, Properties.Resources.TOTP_Setup, OnEntryMenuShowQRClick);
-
-            entryMenuCopyTotp.ShortcutKeys = (Keys)Shortcut.CtrlT;
-            entryMenuSetupTotp.ShortcutKeys = (Keys)Shortcut.CtrlShiftI;
-            entryMenuShowQrCode.ShortcutKeys = (Keys)Shortcut.CtrlShiftJ;
-
+            // The ShortCutKeys assignments are required in this form and
+            // can not be setup as constructor parameters, because an implementation
+            // in the mono framework is missing.
+            // see https://github.com/mono/mono/issues/19755
+            var entryMenuCopyTotp = new ToolStripMenuItem(Localization.Strings.CopyTOTP, Properties.Resources.TOTP, OnEntryMenuTOTPClick)
+            {
+                ShortcutKeys = (Keys)Shortcut.CtrlT
+            };
+            var entryMenuSetupTotp = new ToolStripMenuItem(Localization.Strings.SetupTOTP, Properties.Resources.TOTP_Setup, OnEntryMenuSetupClick)
+            {
+                ShortcutKeys = (Keys)Shortcut.CtrlShiftI
+            };
+            var entryMenuShowQrCode = new ToolStripMenuItem(Localization.Strings.ShowQR, Properties.Resources.TOTP_Setup, OnEntryMenuShowQRClick)
+            {
+                ShortcutKeys = (Keys)Shortcut.CtrlShiftJ
+            };
+            
             rootEntryMenuItem.DropDownItems.Add(entryMenuCopyTotp);
             rootEntryMenuItem.DropDownItems.Add(entryMenuSetupTotp);
             rootEntryMenuItem.DropDownItems.Add(entryMenuShowQrCode);

--- a/KeeTrayTOTP/Menu/EntryMenuItemProvider.cs
+++ b/KeeTrayTOTP/Menu/EntryMenuItemProvider.cs
@@ -13,19 +13,17 @@ namespace KeeTrayTOTP.Menu
         private readonly KeeTrayTOTPExt _plugin;
         private readonly IPluginHost _pluginHost;
 
-        public EntryMenuItemProvider(KeeTrayTOTPExt plugin, IPluginHost pluginHost)
-        {
-            _plugin = plugin;
-            _pluginHost = pluginHost;
-        }
-
         public ToolStripMenuItem ProvideMenuItem()
         {
             var rootEntryMenuItem = new ToolStripMenuItem(Localization.Strings.TrayTOTPPlugin, Properties.Resources.TOTP);
 
-            var entryMenuCopyTotp = new ToolStripMenuItem(Localization.Strings.CopyTOTP, Properties.Resources.TOTP, OnEntryMenuTOTPClick, (Keys)Shortcut.CtrlT);
-            var entryMenuSetupTotp = new ToolStripMenuItem(Localization.Strings.SetupTOTP, Properties.Resources.TOTP_Setup, OnEntryMenuSetupClick, (Keys)Shortcut.CtrlShiftI);
-            var entryMenuShowQrCode = new ToolStripMenuItem(Localization.Strings.ShowQR, Properties.Resources.TOTP_Setup, OnEntryMenuShowQRClick, (Keys)Shortcut.CtrlShiftJ);
+            var entryMenuCopyTotp = new ToolStripMenuItem(Localization.Strings.CopyTOTP, Properties.Resources.TOTP, OnEntryMenuTOTPClick);
+            var entryMenuSetupTotp = new ToolStripMenuItem(Localization.Strings.SetupTOTP, Properties.Resources.TOTP_Setup, OnEntryMenuSetupClick);
+            var entryMenuShowQrCode = new ToolStripMenuItem(Localization.Strings.ShowQR, Properties.Resources.TOTP_Setup, OnEntryMenuShowQRClick);
+
+            entryMenuCopyTotp.ShortcutKeys = (Keys)Shortcut.CtrlT;
+            entryMenuSetupTotp.ShortcutKeys = (Keys)Shortcut.CtrlShiftI;
+            entryMenuShowQrCode.ShortcutKeys = (Keys)Shortcut.CtrlShiftJ;
 
             rootEntryMenuItem.DropDownItems.Add(entryMenuCopyTotp);
             rootEntryMenuItem.DropDownItems.Add(entryMenuSetupTotp);
@@ -56,6 +54,12 @@ namespace KeeTrayTOTP.Menu
             rootEntryMenuItem.DropDownClosed += (sender, args) => entryMenuCopyTotp.Enabled = true;
 
             return rootEntryMenuItem;
+        }
+
+        public EntryMenuItemProvider(KeeTrayTOTPExt plugin, IPluginHost pluginHost)
+        {
+            _plugin = plugin;
+            _pluginHost = pluginHost;
         }
 
         private void OnEntryMenuSetupClick(object sender, EventArgs e)

--- a/KeeTrayTOTP/Menu/EntryMenuItemProvider.cs
+++ b/KeeTrayTOTP/Menu/EntryMenuItemProvider.cs
@@ -13,6 +13,12 @@ namespace KeeTrayTOTP.Menu
         private readonly KeeTrayTOTPExt _plugin;
         private readonly IPluginHost _pluginHost;
 
+        public EntryMenuItemProvider(KeeTrayTOTPExt plugin, IPluginHost pluginHost)
+        {
+            _plugin = plugin;
+            _pluginHost = pluginHost;
+        }
+
         public ToolStripMenuItem ProvideMenuItem()
         {
             var rootEntryMenuItem = new ToolStripMenuItem(Localization.Strings.TrayTOTPPlugin, Properties.Resources.TOTP);
@@ -54,12 +60,6 @@ namespace KeeTrayTOTP.Menu
             rootEntryMenuItem.DropDownClosed += (sender, args) => entryMenuCopyTotp.Enabled = true;
 
             return rootEntryMenuItem;
-        }
-
-        public EntryMenuItemProvider(KeeTrayTOTPExt plugin, IPluginHost pluginHost)
-        {
-            _plugin = plugin;
-            _pluginHost = pluginHost;
         }
 
         private void OnEntryMenuSetupClick(object sender, EventArgs e)


### PR DESCRIPTION
- This fixes #156.
- This was done cause of a bug in mono:
The ToolStripMenuItem constructor which takes an shortcut key, doesn't probably handle
this parameter. see [ToolStripMenuItem.cs of mono](https://github.com/mono/mono/blob/169a842f4e913608b17a1e5f38bcb635063b8dc8/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolStripMenuItem.cs#L83)