### PR TITLE
Reposition tray menu on opening.

### DIFF
--- a/KeeTrayTOTP/Menu/TrayMenuItemProvider.cs
+++ b/KeeTrayTOTP/Menu/TrayMenuItemProvider.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
+using KeeTrayTOTP.Libraries;
 
 namespace KeeTrayTOTP.Menu
 {
@@ -24,6 +25,14 @@ namespace KeeTrayTOTP.Menu
             Plugin = plugin;
             DocumentManager = pluginHost.MainWindow.DocumentManager;
             PluginHost = pluginHost;
+            PluginHost.MainWindow.TrayContextMenu.Opened += TrayContextMenu_Opened;
+        }
+
+        private void TrayContextMenu_Opened(object sender, EventArgs e)
+        {
+            var contextMenuStrip = (ContextMenuStrip)sender;
+            var dropDownLocationCalculator = new DropDownLocationCalculator(contextMenuStrip.Size);
+            contextMenuStrip.Location = dropDownLocationCalculator.CalculateLocationForDropDown(Cursor.Position);
         }
 
         public virtual ToolStripMenuItem ProvideMenuItem()


### PR DESCRIPTION
This fixes #160.
This is probably a .NET bug as this also happens for the ShareX (a C# screenshot tool) tray menu.
This will also show the menu on the screen on which the tray icon was clicked.

### Bug
![grafik](https://user-images.githubusercontent.com/7450586/82086189-a9dd1a80-96dd-11ea-8a7b-b1402ee4a20f.png)


### After fix

![grafik](https://user-images.githubusercontent.com/7450586/82086207-b3668280-96dd-11ea-90af-5b2746ae96e7.png)

