### PR TITLE
Move SonarQube in separate action

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,36 +12,22 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    
+
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.0.0
-    
+
     - name: Setup Nuget.exe
       uses: warrenbuckley/Setup-Nuget@v1
 
     - name: nuget restore
       run: nuget restore KeeTrayTOTP.sln
 
-    - name: Install dotnet-sonarscanner
-      run: dotnet tool install --global dotnet-sonarscanner
-      
-    - name: SonarScanner Begin
-      run: dotnet sonarscanner begin /k:KeeTrayTOTP_KeeTrayTOTP /o:keetraytotp /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths="coverage.opencover.xml"
-
     - name: MSBuild
       run: msbuild KeeTrayTOTP.sln /m
 
     - name: Run tests
       # It looks like the dotnet CLI can no longer build net45 projects? see https://github.com/microsoft/msbuild/issues/4704
-      run: dotnet test --no-build --collect:"XPlat Code Coverage" --settings coverlet.runsettings
-
-    - name: Copy coverage file to root for SonarQube. SonarQube currently does not support wildcards, and the coverage file ends up in a new folder with a random name.
-      run: cp -Path ("KeeTrayTOTP.Tests\TestResults\" + (gci -Path KeeTrayTOTP.Tests\TestResults -Recurse -Force -Name coverage.opencover.xml)) -Destination coverage.opencover.xml
-
-    - name: SonarScanner End
-      run: dotnet sonarscanner end
-      env:
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      run: dotnet test --no-build
 
     - name: MSBuild (With Plgx)
       run: msbuild KeeTrayTOTP.sln /p:Configuration=ReleasePlgx
@@ -51,7 +37,7 @@ jobs:
       with:
         name: KeeTrayTOTP.plgx
         path: KeeTrayTOTP\bin\ReleasePlgx\KeeTrayTOTP.plgx
-        
+
   build-mono:
     runs-on: ubuntu-latest
 
@@ -62,7 +48,7 @@ jobs:
       run: sudo apt -y install xvfb
 
     - name: Download nuget.exe
-      run: wget https://dist.nuget.org/win-x86-commandline/latest/nuget.exe 
+      run: wget https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
 
     - name: nuget restore
       run: mono nuget.exe restore

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -4,7 +4,7 @@ name: "KeeTrayTOTP Pre Release"
 on:
   push:
     branches:
-      - 'master' 
+      - 'master'
     tags-ignore:
       - '*'
 env:
@@ -17,36 +17,24 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    
+
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.0.0
-    
+
     - name: Setup Nuget.exe
       uses: warrenbuckley/Setup-Nuget@v1
 
     - name: nuget restore
       run: nuget restore KeeTrayTOTP.sln
 
-    - name: Install dotnet-sonarscanner
-      run: dotnet tool install --global dotnet-sonarscanner
-      
-    - name: SonarScanner Begin
-      run: dotnet sonarscanner begin /k:KeeTrayTOTP_KeeTrayTOTP /o:keetraytotp /d:sonar.host.url="https://sonarcloud.io"
-
     - name: MSBuild (With Plgx)
       run: msbuild KeeTrayTOTP.sln /p:Configuration=ReleasePlgx
-
-    - name: SonarScanner End
-      run: dotnet sonarscanner end
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
     - name: Upload plgx
       uses: actions/upload-artifact@v1
       with:
         name: KeeTrayTOTP.plgx
-        path: KeeTrayTOTP\bin\ReleasePlgx\KeeTrayTOTP.plgx        
+        path: KeeTrayTOTP\bin\ReleasePlgx\KeeTrayTOTP.plgx
 
     - name: Create prerelease
       uses: "marvinpinto/action-automatic-releases@latest"

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,0 +1,53 @@
+name: SonarQube
+
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the master branch
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+env:
+  DOTNET_NOLOGO: 1
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.0
+
+    - name: Setup Nuget.exe
+      uses: warrenbuckley/Setup-Nuget@v1
+
+    - name: nuget restore
+      run: nuget restore KeeTrayTOTP.sln
+
+    - name: Install dotnet-sonarscanner
+      run: dotnet tool install --global dotnet-sonarscanner
+
+    - name: SonarScanner Begin
+      run: dotnet sonarscanner begin /k:KeeTrayTOTP_KeeTrayTOTP /o:keetraytotp /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths="coverage.opencover.xml"
+
+    - name: MSBuild
+      run: msbuild KeeTrayTOTP.sln /m
+
+    - name: Run tests
+      # It looks like the dotnet CLI can no longer build net45 projects? see https://github.com/microsoft/msbuild/issues/4704
+      run: dotnet test --no-build --collect:"XPlat Code Coverage" --settings coverlet.runsettings
+
+      # Copy coverage file to root for SonarQube.
+      # SonarQube currently does not support wildcards, and the coverage file ends up in a new folder with a random name.
+    - name: Copy coverage file
+      run: cp -Path ("KeeTrayTOTP.Tests\TestResults\" + (gci -Path KeeTrayTOTP.Tests\TestResults -Recurse -Force -Name coverage.opencover.xml)) -Destination coverage.opencover.xml
+
+    - name: SonarScanner End
+      run: dotnet sonarscanner end
+      env:
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Separate SonarQube actions in a separate workflow, so that it will also collect data on the master branch that is considered as the baseline. This will also make the (pre)release process less risky, because there is less work to do.

There is a bit of duplication between the PR build and the SonarQube action, but I think that's fine for now.