### PR TITLE
Improve dropdown menu

### DIFF
--- a/KeeTrayTOTP.Tests/Menu/LegacyTrayMenuTests.cs
+++ b/KeeTrayTOTP.Tests/Menu/LegacyTrayMenuTests.cs
@@ -16,7 +16,7 @@ namespace KeeTrayTOTP.Tests.Menu
 
             var sut = legacyTrayMenuItemProvider.ProvideMenuItem();
 
-            sut.Should().BeNull();
+            sut.Should().BeNull("because we do not provide an official tray menu item in legacy mode.");
         }
 
         [TestMethod]
@@ -30,7 +30,7 @@ namespace KeeTrayTOTP.Tests.Menu
 
             var sut = host.Object.MainWindow.TrayContextMenu.Items.Count;
 
-            sut.Should().Be(oldItemCount + 2);
+            sut.Should().Be(oldItemCount + 2, "because we inject two menu items into the official KeePass tray menu");
         }
     }
 }

--- a/KeeTrayTOTP.Tests/Menu/MenuItemProviderTests.cs
+++ b/KeeTrayTOTP.Tests/Menu/MenuItemProviderTests.cs
@@ -51,7 +51,7 @@ namespace KeeTrayTOTP.Tests.Menu
 
             trayMenuItem.Should().NotBeNull();
             trayMenuItem.HasDropDownItems.Should().BeTrue();
-            trayMenuItem.DropDownItems.Should().HaveCount(1, "because, there should be a pseudo entry.");
+            trayMenuItem.DropDownItems.Should().HaveCount(0, "because, the entries are added at opening of the menu.");
         }
 
         [TestMethod]

--- a/KeeTrayTOTP.Tests/Menu/ToolStripMenuItemExTests.cs
+++ b/KeeTrayTOTP.Tests/Menu/ToolStripMenuItemExTests.cs
@@ -1,0 +1,47 @@
+﻿using FluentAssertions;
+using KeePass.UI;
+using KeeTrayTOTP.Menu;
+using KeeTrayTOTP.Tests.Extensions;
+using KeeTrayTOTP.Tests.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using KeeTrayTOTP.Helpers;
+
+namespace KeeTrayTOTP.Tests.Menu
+{
+    [TestClass]
+    public class ToolStripMenuItemExTests
+    {
+        [TestMethod]
+        public void ToolStripMenuItemEx_ShouldReturnHasDropDownItems_EvenIfEmpty()
+        {
+            var sut = new ToolStripMenuItemEx("foo", new Bitmap(1,1));
+            sut.ForceDropDownArrow = true;
+
+            sut.HasDropDownItems.Should()
+                .BeTrue("because we want to display the dropdown arrow even if there are no items present");
+        }
+
+        [TestMethod]
+        public void ToolStripMenuItemEx_ShouldHaveDefaultBehavior_IfForceDropDownArrowIsNotSet()
+        {
+            var sut = new ToolStripMenuItemEx("foo", new Bitmap(1, 1));
+
+            sut.HasDropDownItems.Should()
+                .BeFalse("because it's the default behavior");
+        }
+
+        [TestMethod]
+        public void ToolStripMenuItemEx_ShouldHaveDefaultBehavior_IfForceDropDownArrowIsNotSet2()
+        {
+            var sut = new ToolStripMenuItemEx("foo", new Bitmap(1, 1));
+            sut.DropDownItems.Add("bar");
+
+            sut.HasDropDownItems.Should()
+                .BeTrue("because it's the default behavior");
+        }
+
+    }
+}

--- a/KeeTrayTOTP/Helpers/ToolStripMenuItemEx.cs
+++ b/KeeTrayTOTP/Helpers/ToolStripMenuItemEx.cs
@@ -8,15 +8,6 @@ namespace KeeTrayTOTP.Helpers
     [DesignerCategory("")]
     public class ToolStripMenuItemEx : ToolStripMenuItem
     {
-        public ToolStripMenuItemEx()
-        {
-            ForceDropDownArrow = false;
-        }
-
-        public ToolStripMenuItemEx(string text) : base(text)
-        {
-        }
-
         public ToolStripMenuItemEx(string text, Image image) : base(text, image)
         {
         }

--- a/KeeTrayTOTP/Helpers/ToolStripMenuItemEx.cs
+++ b/KeeTrayTOTP/Helpers/ToolStripMenuItemEx.cs
@@ -10,6 +10,7 @@ namespace KeeTrayTOTP.Helpers
     {
         public ToolStripMenuItemEx()
         {
+            ForceDropDownArrow = false;
         }
 
         public ToolStripMenuItemEx(string text) : base(text)
@@ -43,6 +44,19 @@ namespace KeeTrayTOTP.Helpers
                 }
 
                 return dropDownLocation;
+            }
+        }
+
+        /// <summary>
+        /// Controls whether the drop-down arrow is displayed even if there are no visible drop-down items
+        /// </summary>
+        public bool ForceDropDownArrow { get; set; }
+
+        public override bool HasDropDownItems
+        {
+            get
+            {
+                return ForceDropDownArrow || base.HasDropDownItems;
             }
         }
     }

--- a/KeeTrayTOTP/Menu/TrayMenuItemProvider.cs
+++ b/KeeTrayTOTP/Menu/TrayMenuItemProvider.cs
@@ -38,11 +38,9 @@ namespace KeeTrayTOTP.Menu
         public virtual ToolStripMenuItem ProvideMenuItem()
         {
             var rootTrayMenuItem = new ToolStripMenuItemEx(Localization.Strings.TrayTOTPPlugin, Resources.TOTP);
-
-            rootTrayMenuItem.DropDownItems.Add(CreatePseudoToolStripMenuItem());
+            rootTrayMenuItem.ForceDropDownArrow = true;
             rootTrayMenuItem.DropDownOpening += OnRootDropDownOpening;
             rootTrayMenuItem.DropDownOpening += MenuItemHelper.OnDatabaseDropDownOpening;
-            rootTrayMenuItem.DropDownClosed += OnDropDownClosed;
 
             return rootTrayMenuItem;
         }
@@ -96,10 +94,9 @@ namespace KeeTrayTOTP.Menu
             {
                 var documentName = UrlUtil.GetFileName(document.Database.IOConnectionInfo.Path);
                 mainDropDownItem = new ToolStripMenuItemEx(documentName, ImageExtensions.CreateImageFromColor(document.Database.Color));
+                mainDropDownItem.ForceDropDownArrow = true;
                 mainDropDownItem.DropDownOpening += OnDatabaseDropDownOpening;
                 mainDropDownItem.DropDownOpening += MenuItemHelper.OnDatabaseDropDownOpening;
-                mainDropDownItem.DropDownClosed += OnDropDownClosed;
-                mainDropDownItem.DropDownItems.Add(CreatePseudoToolStripMenuItem());
             }
 
             mainDropDownItem.Tag = document;
@@ -184,27 +181,6 @@ namespace KeeTrayTOTP.Menu
                     Tag = pwDocument
                 }
             };
-        }
-
-        /// <summary>
-        ///     This menu item is required to show the dropdown arrow in the tray context menu,
-        ///     even if the menu is still empty. (because we don't fill it until the opening event)
-        /// </summary>
-        private static ToolStripMenuItem CreatePseudoToolStripMenuItem()
-        {
-            return new ToolStripMenuItem();
-        }
-
-        private void OnDropDownClosed(object sender, EventArgs e)
-        {
-            var rootMenuItem = sender as ToolStripMenuItem;
-            if (rootMenuItem == null)
-            {
-                return;
-            }
-
-            rootMenuItem.DropDownItems.Clear();
-            rootMenuItem.DropDownItems.Add(new ToolStripMenuItem());
         }
 
         protected ToolStripMenuItem CreateMenuItemFromPwEntry(PwEntry entry, PwDatabase pwDatabase)


### PR DESCRIPTION
This commit is removing the need for a pseudo item that was required to always display an dropdown arrow, because we are computing the real entries on-the-fly at the opening of the dropdown.

Also:
- Added some unit tests
- Improved because-clause of other unit tests