### PR TITLE
Add github token to SonarQube build

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -51,3 +51,4 @@ jobs:
       run: dotnet sonarscanner end
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Did not notice this was necessary, until the master build kicked in.