### PR TITLE
Bump java version

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -19,6 +19,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-java@v1
+      with:
+        java-version: '13' # The JDK version to make available on the path.
+        java-package: jdk # (jre, jdk, or jdk+fx) - defaults to jdk
+        architecture: x64 # (x64 or x86) - defaults to x64
 
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.0.0


### PR DESCRIPTION
SonarQube started giving warnings on the java version used in github actions:

> It appears that you are still using Java 8 for the analysis of your projects. The version of Java installed in the scanner environment should be upgraded to at least Java 11 by October 2020.Please upgrade these projects now:
> * KeeTrayTOTP (KeeTrayTOTP)

