### PR TITLE
Add hashes.txt on (pre)-release

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -36,6 +36,16 @@ jobs:
         name: KeeTrayTOTP.plgx
         path: KeeTrayTOTP\bin\ReleasePlgx\KeeTrayTOTP.plgx
 
+    - name: Generate hashes
+      run: |
+        Add-Content hashes.txt "Filename: KeeTrayTOTP.plgx"
+        Add-Content hashes.txt "=========================="
+        foreach ($algorithm in (Get-Command Get-FileHash).Parameters["Algorithm"].Attributes[1].ValidValues)
+        {
+            Add-Content hashes.txt "${algorithm}: $((Get-FileHash KeeTrayTOTP\bin\ReleasePlgx\KeeTrayTOTP.plgx -Algorithm $algorithm).Hash)"
+        }
+      shell: pwsh
+        
     - name: Create prerelease
       uses: "marvinpinto/action-automatic-releases@latest"
       with:
@@ -45,3 +55,4 @@ jobs:
         title: "Development Build"
         files: |
            **/KeeTrayTOTP.plgx
+           hashes.txt

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -35,6 +35,16 @@ jobs:
         name: KeeTrayTOTP.plgx
         path: KeeTrayTOTP\bin\ReleasePlgx\KeeTrayTOTP.plgx
 
+    - name: Generate hashes
+      run: |
+        Add-Content hashes.txt "Filename: KeeTrayTOTP.plgx"
+        Add-Content hashes.txt "=========================="
+        foreach ($algorithm in (Get-Command Get-FileHash).Parameters["Algorithm"].Attributes[1].ValidValues)
+        {
+            Add-Content hashes.txt "${algorithm}: $((Get-FileHash KeeTrayTOTP\bin\ReleasePlgx\KeeTrayTOTP.plgx -Algorithm $algorithm).Hash)"
+        }
+      shell: pwsh
+
     - name: Create release
       uses: "marvinpinto/action-automatic-releases@latest"
       with:
@@ -42,3 +52,4 @@ jobs:
         prerelease: false
         files: |
            **/KeeTrayTOTP.plgx
+           hashes.txt


### PR DESCRIPTION
__Added__: 

When a release and pre-release is created, a file is attached that looks like this:

```
Filename: KeeTrayTOTP.plgx
==========================
SHA1: 849109F1C7B0BA00567B49162E5ED84B0D56D674
SHA256: E5313F44352A46532FECE8BB6B35498C9B3658545CA60F78957CFFAB7160E8FD
SHA384: 31D558FDF24ECC9F017334243EBB1C1047ADC7DA4C08EC1370C5A4E60309E8701DC134869EE56ADE5C8AACDD61B35394
SHA512: 23976FE5C46F9F4058380CFDDA751CFDC5352CD68C6D29AD927E16EF8D483B2E366C13E3D44E02DC5A946803286F17C63F084B7E2F4A1950764C317F147FFC48
MD5: EBD8931C1C6AC282BD46A645B5F8E20B
```

Fixes #187

Tested this in my fork.