### PR TITLE
Ensure TOTP value counter is ticking after defining OTP

### DIFF
--- a/KeeTrayTOTP/SetupTOTP.cs
+++ b/KeeTrayTOTP/SetupTOTP.cs
@@ -193,6 +193,7 @@ namespace KeeTrayTOTP
                 _entry.Touch(true);
 
                 _plugin.PluginHost.MainWindow.ActiveDatabase.Modified = true;
+                _plugin.ResetLastSelectedGroup();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Fixes #192 

Changes in `OnTimerTick` and `UIStateUpdated` are not required for the fix to work, nevertheles I think they should be added for performance reasons
- Read entries of subgroups only if entries of subgroups are displayed as well
- Stop looking for valid OTP settings after the first hit