### PR TITLE
Github actions fail

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,10 +14,10 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1.0.2
 
     - name: Setup Nuget.exe
-      uses: warrenbuckley/Setup-Nuget@v1
+      uses: nuget/setup-nuget@v1
 
     - name: nuget restore
       run: nuget restore KeeTrayTOTP.sln

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -19,10 +19,10 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1.0.2
 
     - name: Setup Nuget.exe
-      uses: warrenbuckley/Setup-Nuget@v1
+      uses: nuget/setup-nuget@v1
 
     - name: nuget restore
       run: nuget restore KeeTrayTOTP.sln

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -26,7 +26,7 @@ jobs:
         architecture: x64 # (x64 or x86) - defaults to x64
 
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1.0.2
 
     - name: Setup Nuget.exe
       uses: warrenbuckley/Setup-Nuget@v1

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -29,7 +29,7 @@ jobs:
       uses: microsoft/setup-msbuild@v1.0.2
 
     - name: Setup Nuget.exe
-      uses: warrenbuckley/Setup-Nuget@v1
+      uses: nuget/setup-nuget@v1
 
     - name: nuget restore
       run: nuget restore KeeTrayTOTP.sln

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -18,10 +18,10 @@ jobs:
     - uses: actions/checkout@v2
     
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.0
-    
+      uses: microsoft/setup-msbuild@v1.0.2
+
     - name: Setup Nuget.exe
-      uses: warrenbuckley/Setup-Nuget@v1
+      uses: nuget/setup-nuget@v1
 
     - name: nuget restore
       run: nuget restore KeeTrayTOTP.sln


### PR DESCRIPTION
Update github actions workflow to fix "The `add-path` command is disabled." issues.